### PR TITLE
Architecture buff

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,7 +138,7 @@ jobs:
           usesh: true
           prepare: |
             pkg install -y ca_root_nss git rubygem-bundler
-            pkg install -y ruby34
+            pkg install -y ruby
           run: |
             RUBY_BIN="$(command -v ruby34 || command -v ruby)"
             "$RUBY_BIN" -v

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,17 +8,21 @@ on:
 
 jobs:
   lint:
-    name: Lint (ubuntu-latest)
+    name: Lint (Ruby ${{ matrix.ruby-version }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby-version: ['3.4', '3.5', '4.0']
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Set up Ruby 4.0.0
+      - name: Set up Ruby ${{ matrix.ruby-version }}
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 4.0.0
+          ruby-version: ${{ matrix.ruby-version }}
           bundler-cache: true
 
       - name: Debug versions
@@ -31,59 +35,65 @@ jobs:
         run: bundle exec rubocop
 
   test_linux:
-    name: Test (ubuntu-latest)
+    name: Test (Ruby ${{ matrix.ruby-version }}, ubuntu-latest)
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby-version: ['3.4', '3.5', '4.0']
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Set up Ruby 4.0.0
+      - name: Set up Ruby ${{ matrix.ruby-version }}
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 4.0.0
+          ruby-version: ${{ matrix.ruby-version }}
           bundler-cache: true
 
       - name: Run tests
         run: bundle exec rspec
 
   test_non_linux:
-    name: Test (${{ matrix.os }})
+    name: Test (Ruby ${{ matrix.ruby-version }}, ${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os: [macos-latest, windows-latest]
+        ruby-version: ['3.4', '4.0']
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Set up Ruby 4.0.0
+      - name: Set up Ruby ${{ matrix.ruby-version }}
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 4.0.0
+          ruby-version: ${{ matrix.ruby-version }}
           bundler-cache: true
 
       - name: Run tests
         run: bundle exec rspec
 
   smoke_unix:
-    name: Start CLI (${{ matrix.os }})
+    name: Start CLI (Ruby ${{ matrix.ruby-version }}, ${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
+        ruby-version: ['3.4', '4.0']
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Set up Ruby 4.0.0
+      - name: Set up Ruby ${{ matrix.ruby-version }}
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 4.0.0
+          ruby-version: ${{ matrix.ruby-version }}
           bundler-cache: true
 
       - name: Start CLI
@@ -92,17 +102,21 @@ jobs:
           bundle exec bin/neocities-red
 
   smoke_windows:
-    name: Start CLI (windows-latest)
+    name: Start CLI (Ruby ${{ matrix.ruby-version }}, windows-latest)
     runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby-version: ['3.4', '4.0']
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Set up Ruby 4.0.0
+      - name: Set up Ruby ${{ matrix.ruby-version }}
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 4.0.0
+          ruby-version: ${{ matrix.ruby-version }}
           bundler-cache: true
 
       - name: Start CLI

--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,10 @@ Thumbs.db
 coverage/
 *.lcov
 
+# YARD documentation
+doc/
+.yardoc
+
 # Temporary files
 tmp/
 *.log

--- a/.yardopts
+++ b/.yardopts
@@ -1,0 +1,13 @@
+--markup markdown
+--output-dir doc
+--protected
+--private
+--no-cache
+--readme README.md
+--title "NeocitiesRed"
+--exclude spec/
+--exclude ext/
+-
+LICENSE
+CONTRIBUTING.md
+SECURITY.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,95 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/),
+and this project adheres to [Semantic Versioning](https://semver.org/).
+
+## [Unreleased]
+
+## [1.2.0] — 2026-08-04
+
+### Changed
+
+- Major architecture refactor with namespaced services (`file/`, `site/`, `common/`)
+- Renamed gem to `neocities-red`
+
+### Added
+
+- YARD documentation
+
+### Removed
+
+- Unused legacy code
+
+## [1.1.2] — 2026-08-04
+
+### Changed
+
+- Bumped rubocop to 1.88.2, rubocop-rspec to 3.10.2, faraday to 2.14.3
+
+## [1.1.1] — 2026-06-22
+
+### Fixed
+
+- Config for Windows/FreeBSD platforms
+- Purge no longer removes already-removed files
+
+### Changed
+
+- `upload` accepts a single parameter
+- Bumped rake to 13.4.2
+
+## [1.1.0] — 2026-04-25
+
+### Changed
+
+- Added Rails/Thor CLI framework, refactored `cli.rb`
+
+## [1.0.6] — 2026-04-14
+
+### Fixed
+
+- Tests and lint fixes
+- Added `faraday-retry` for flaky API/SSL handling
+
+## [1.0.4] — 2026-03-29
+
+### Changed
+
+- CLI version display updated
+
+## [1.0.2] — 2026-02-11
+
+### Added
+
+- Multithreaded parallel uploads
+- Fixed recursive uploading in `upload` method
+
+## [1.0.1] — 2026-02-07
+
+### Added
+
+- Folder uploading support
+
+## [1.0.0] — 2026-02-11
+
+### Added
+
+- Initial release of `neocities-red` (fork of `neocities-ruby`)
+- Recursive uploads with smart diffing
+- `push`, `upload`, `delete`, `diff`, `list`, `info`, `pull` commands
+- Parallel upload workers
+- Automatic retries
+- Config file with `NEOCITIES_API_KEY` support
+
+[Unreleased]: https://github.com/o-200/neocities-red/compare/v1.2.0...HEAD
+[1.2.0]: https://github.com/o-200/neocities-red/compare/v1.1.2...v1.2.0
+[1.1.2]: https://github.com/o-200/neocities-red/compare/v1.1.1...v1.1.2
+[1.1.1]: https://github.com/o-200/neocities-red/compare/v1.1.0...v1.1.1
+[1.1.0]: https://github.com/o-200/neocities-red/compare/v1.0.6...v1.1.0
+[1.0.6]: https://github.com/o-200/neocities-red/compare/v1.0.4...v1.0.6
+[1.0.4]: https://github.com/o-200/neocities-red/compare/v1.0.2...v1.0.4
+[1.0.2]: https://github.com/o-200/neocities-red/compare/v1.0.1...v1.0.2
+[1.0.1]: https://github.com/o-200/neocities-red/compare/v1.0.0...v1.0.1
+[1.0.0]: https://github.com/o-200/neocities-red/releases/tag/v1.0.0

--- a/Gemfile
+++ b/Gemfile
@@ -9,4 +9,5 @@ group :test, :development do
   gem "rubocop", "~> 1.88.2"
   gem "rubocop-rspec", "~> 3.10.2"
   gem "webmock"
+  gem "yard"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    neocities-red (1.1.1)
+    neocities-red (1.1.2)
       faraday (~> 2.14.3)
       faraday-follow_redirects
       faraday-multipart
@@ -20,7 +20,7 @@ GEM
     addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)
     ast (2.4.3)
-    bigdecimal (4.1.1)
+    bigdecimal (4.1.2)
     crack (1.0.1)
       bigdecimal
       rexml
@@ -39,15 +39,15 @@ GEM
       faraday (~> 2.0)
     fiddle (1.1.8)
     hashdiff (1.2.1)
-    json (2.21.1)
-    language_server-protocol (3.17.0.5)
+    json (2.21.2)
+    language_server-protocol (3.17.0.6)
     lint_roller (1.1.0)
     logger (1.7.0)
     multipart-post (2.4.1)
     net-http (0.9.1)
       uri (>= 0.11.1)
-    parallel (2.0.1)
-    parser (3.3.11.1)
+    parallel (2.1.0)
+    parser (3.3.12.0)
       ast (~> 2.4.1)
       racc
     pastel (0.8.0)
@@ -83,7 +83,7 @@ GEM
       rubocop-ast (>= 1.49.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 4.0)
-    rubocop-ast (1.49.1)
+    rubocop-ast (1.50.0)
       parser (>= 3.3.7.2)
       prism (~> 1.7)
     rubocop-rspec (3.10.2)
@@ -125,7 +125,6 @@ GEM
 
 PLATFORMS
   ruby
-  x64-mingw-ucrt
   x86_64-linux
 
 DEPENDENCIES
@@ -138,7 +137,8 @@ DEPENDENCIES
 CHECKSUMS
   addressable (2.9.0) sha256=7fdf6ac3660f7f4e867a0838be3f6cf722ace541dd97767fa42bc6cfa980c7af
   ast (2.4.3) sha256=954615157c1d6a382bc27d690d973195e79db7f55e9765ac7c481c60bdb4d383
-  bigdecimal (4.1.1) sha256=1c09efab961da45203c8316b0cdaec0ff391dfadb952dd459584b63ebf8054ca
+  bigdecimal (4.1.2) sha256=53d217666027eab4280346fba98e7d5b66baaae1b9c3c1c0ffe89d48188a3fbd
+  bundler (4.0.17) sha256=214e21431b5665dd2f99df8a5511c6b151d7a72e8015c8b38f8b775b61cbb6c1
   crack (1.0.1) sha256=ff4a10390cd31d66440b7524eb1841874db86201d5b70032028553130b6d4c7e
   diff-lcs (1.6.2) sha256=9ae0d2cba7d4df3075fe8cd8602a8604993efc0dfa934cff568969efb1909962
   faraday (2.14.3) sha256=1882247e6766615c8220b4392bf1d27f6ebb63d8e28267587cef1fb0bf37f278
@@ -148,15 +148,15 @@ CHECKSUMS
   faraday-retry (2.4.0) sha256=7b79c48fb7e56526faf247b12d94a680071ff40c9fda7cf1ec1549439ad11ebe
   fiddle (1.1.8) sha256=7fa8ee3627271497f3add5503acdbc3f40b32f610fc1cf49634f083ef3f32eee
   hashdiff (1.2.1) sha256=9c079dbc513dfc8833ab59c0c2d8f230fa28499cc5efb4b8dd276cf931457cd1
-  json (2.21.1) sha256=13a43df75d95641443f5702dff350f237164a9d811ff0f2c2800d4d980220583
-  language_server-protocol (3.17.0.5) sha256=fd1e39a51a28bf3eec959379985a72e296e9f9acfce46f6a79d31ca8760803cc
+  json (2.21.2) sha256=1f1d3b7cf2b3ba1a69beca0bb6db13d5438b80bff3cd54cdaaa620b9b07c1c6a
+  language_server-protocol (3.17.0.6) sha256=5ef2c0c138f8267e1bc631d3328347d354f96724b0af22f2c79516120443b7f0
   lint_roller (1.1.0) sha256=2c0c845b632a7d172cb849cc90c1bce937a28c5c8ccccb50dfd46a485003cc87
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
   multipart-post (2.4.1) sha256=9872d03a8e552020ca096adadbf5e3cb1cd1cdd6acd3c161136b8a5737cdb4a8
-  neocities-red (1.1.1)
+  neocities-red (1.1.2)
   net-http (0.9.1) sha256=25ba0b67c63e89df626ed8fac771d0ad24ad151a858af2cc8e6a716ca4336996
-  parallel (2.0.1) sha256=337782d3e39f4121e67563bf91dd8ece67f48923d90698614773a0ec9a5b2c7d
-  parser (3.3.11.1) sha256=d17ace7aabe3e72c3cc94043714be27cc6f852f104d81aa284c2281aecc65d54
+  parallel (2.1.0) sha256=b35258865c2e31134c5ecb708beaaf6772adf9d5efae28e93e99260877b09356
+  parser (3.3.12.0) sha256=21a6d7f755d5a24dfbdc6e6b772e4e879a52e7631a88bc5a3a134606052c9828
   pastel (0.8.0) sha256=481da9fb7d2f6e6b1a08faf11fa10363172dc40fd47848f096ae21209f805a75
   prism (1.9.0) sha256=7b530c6a9f92c24300014919c9dcbc055bf4cdf51ec30aed099b06cd6674ef85
   public_suffix (7.0.5) sha256=1a8bb08f1bbea19228d3bed6e5ed908d1cb4f7c2726d18bd9cadf60bc676f623
@@ -171,7 +171,7 @@ CHECKSUMS
   rspec-mocks (3.13.8) sha256=086ad3d3d17533f4237643de0b5c42f04b66348c28bf6b9c2d3f4a3b01af1d47
   rspec-support (3.13.7) sha256=0640e5570872aafefd79867901deeeeb40b0c9875a36b983d85f54fb7381c47c
   rubocop (1.88.2) sha256=8def251c90cd955feb4daa3edc0ab56893250c4ce90ef81e6c80c03f9a939bbf
-  rubocop-ast (1.49.1) sha256=4412f3ee70f6fe4546cc489548e0f6fcf76cafcfa80fa03af67098ffed755035
+  rubocop-ast (1.50.0) sha256=b9ca88300da0803ee222ad20cdb30494c0a784eed06fdc35d254b06d662788db
   rubocop-rspec (3.10.2) sha256=0b3e2ecc592cd10ecbf0095bb58d1e357905276e069643523cc19eb7495f65e2
   ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
   strings (0.2.1) sha256=933293b3c95cf85b81eb44b3cf673e3087661ba739bbadfeadf442083158d6fb
@@ -191,4 +191,4 @@ CHECKSUMS
   wisper (2.0.1) sha256=ce17bc5c3a166f241a2e6613848b025c8146fce2defba505920c1d1f3f88fae6
 
 BUNDLED WITH
-  4.0.6
+  4.0.17

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    neocities-red (1.1.2)
+    neocities-red (1.2.0)
       faraday (~> 2.14.3)
       faraday-follow_redirects
       faraday-multipart
@@ -122,6 +122,7 @@ GEM
       json
       unicode-display_width (>= 1.1)
     wisper (2.0.1)
+    yard (0.9.45)
 
 PLATFORMS
   ruby
@@ -133,6 +134,7 @@ DEPENDENCIES
   rubocop (~> 1.88.2)
   rubocop-rspec (~> 3.10.2)
   webmock
+  yard
 
 CHECKSUMS
   addressable (2.9.0) sha256=7fdf6ac3660f7f4e867a0838be3f6cf722ace541dd97767fa42bc6cfa980c7af
@@ -153,7 +155,7 @@ CHECKSUMS
   lint_roller (1.1.0) sha256=2c0c845b632a7d172cb849cc90c1bce937a28c5c8ccccb50dfd46a485003cc87
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
   multipart-post (2.4.1) sha256=9872d03a8e552020ca096adadbf5e3cb1cd1cdd6acd3c161136b8a5737cdb4a8
-  neocities-red (1.1.2)
+  neocities-red (1.2.0)
   net-http (0.9.1) sha256=25ba0b67c63e89df626ed8fac771d0ad24ad151a858af2cc8e6a716ca4336996
   parallel (2.1.0) sha256=b35258865c2e31134c5ecb708beaaf6772adf9d5efae28e93e99260877b09356
   parser (3.3.12.0) sha256=21a6d7f755d5a24dfbdc6e6b772e4e879a52e7631a88bc5a3a134606052c9828
@@ -189,6 +191,7 @@ CHECKSUMS
   webmock (3.26.2) sha256=774556f2ea6371846cca68c01769b2eac0d134492d21f6d0ab5dd643965a4c90
   whirly (0.4.0) sha256=3ffdf9097e711097442f6d83c91b8fc431d73224863f75b48f06fb850b3e596e
   wisper (2.0.1) sha256=ce17bc5c3a166f241a2e6613848b025c8146fce2defba505920c1d1f3f88fae6
+  yard (0.9.45)
 
 BUNDLED WITH
   4.0.17

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,11 +7,11 @@ PATH
       faraday-multipart
       faraday-retry
       fiddle
-      pastel (~> 0.8, = 0.8.0)
-      rake (~> 13, >= 13.3.0)
+      pastel (= 0.8.0)
+      rake (~> 13)
       thor (~> 1.5.0, >= 1.5.0)
-      tty-prompt (~> 0.23, = 0.23.1)
-      tty-table (~> 0.12, = 0.12.0)
+      tty-prompt (= 0.23.1)
+      tty-table (= 0.12.0)
       whirly (~> 0.3, >= 0.3.0)
 
 GEM
@@ -191,7 +191,7 @@ CHECKSUMS
   webmock (3.26.2) sha256=774556f2ea6371846cca68c01769b2eac0d134492d21f6d0ab5dd643965a4c90
   whirly (0.4.0) sha256=3ffdf9097e711097442f6d83c91b8fc431d73224863f75b48f06fb850b3e596e
   wisper (2.0.1) sha256=ce17bc5c3a166f241a2e6613848b025c8146fce2defba505920c1d1f3f88fae6
-  yard (0.9.45)
+  yard (0.9.45) sha256=52e211493f7cb8a3ebf7e104a25a1e73937a3103092545d34cb88fafebb3dc51
 
 BUNDLED WITH
   4.0.17

--- a/README.md
+++ b/README.md
@@ -136,6 +136,12 @@ Current service namespaces:
 
 ---
 
+## Changelog
+
+See [CHANGELOG.md](CHANGELOG.md) for release history.
+
+---
+
 ## Contributing
 
 see CONTRIBUTING.md

--- a/lib/neocities_red.rb
+++ b/lib/neocities_red.rb
@@ -1,20 +1,36 @@
 # frozen_string_literal: true
 
-require File.join(File.dirname(__FILE__), "neocities_red", "version")
-require File.join(File.dirname(__FILE__), "neocities_red", "errors")
-require File.join(File.dirname(__FILE__), "neocities_red", "client")
-require File.join(File.dirname(__FILE__), "neocities_red", "cli_display")
-require File.join(File.dirname(__FILE__), "neocities_red", "cli")
+# Top-level namespace for the NeocitiesRed gem.
+#
+# Provides a CLI tool and Ruby API client for managing static sites
+# hosted on {https://neocities.org Neocities.org}.
+#
+# @see NeocitiesRed::Client HTTP API client
+# @see NeocitiesRed::CLI Command-line interface
+module NeocitiesRed
+  # Service layer organized by domain.
+  #
+  # - {Services::File} — single-file and folder-level operations (upload, delete, list)
+  # - {Services::Site} — site-level operations (push, diff, info, export)
+  # - {Services::Common} — shared utilities (exclusions, worker pool)
+  module Services; end
 
-require File.join(File.dirname(__FILE__), "neocities_red", "services", "file", "uploader")
-require File.join(File.dirname(__FILE__), "neocities_red", "services", "file", "folder_uploader")
-require File.join(File.dirname(__FILE__), "neocities_red", "services", "file", "remover")
-require File.join(File.dirname(__FILE__), "neocities_red", "services", "file", "list")
+  require File.join(File.dirname(__FILE__), "neocities_red", "version")
+  require File.join(File.dirname(__FILE__), "neocities_red", "errors")
+  require File.join(File.dirname(__FILE__), "neocities_red", "client")
+  require File.join(File.dirname(__FILE__), "neocities_red", "cli_display")
+  require File.join(File.dirname(__FILE__), "neocities_red", "cli")
 
-require File.join(File.dirname(__FILE__), "neocities_red", "services", "site", "differencer")
-require File.join(File.dirname(__FILE__), "neocities_red", "services", "site", "informer")
-require File.join(File.dirname(__FILE__), "neocities_red", "services", "site", "exporter")
-require File.join(File.dirname(__FILE__), "neocities_red", "services", "site", "pusher")
-require File.join(File.dirname(__FILE__), "neocities_red", "services", "common", "exclusions")
-require File.join(File.dirname(__FILE__), "neocities_red", "services", "common", "worker_pool")
-require File.join(File.dirname(__FILE__), "neocities_red", "services", "common", "pizza")
+  require File.join(File.dirname(__FILE__), "neocities_red", "services", "file", "uploader")
+  require File.join(File.dirname(__FILE__), "neocities_red", "services", "file", "folder_uploader")
+  require File.join(File.dirname(__FILE__), "neocities_red", "services", "file", "remover")
+  require File.join(File.dirname(__FILE__), "neocities_red", "services", "file", "list")
+
+  require File.join(File.dirname(__FILE__), "neocities_red", "services", "site", "differencer")
+  require File.join(File.dirname(__FILE__), "neocities_red", "services", "site", "informer")
+  require File.join(File.dirname(__FILE__), "neocities_red", "services", "site", "exporter")
+  require File.join(File.dirname(__FILE__), "neocities_red", "services", "site", "pusher")
+  require File.join(File.dirname(__FILE__), "neocities_red", "services", "common", "exclusions")
+  require File.join(File.dirname(__FILE__), "neocities_red", "services", "common", "worker_pool")
+  require File.join(File.dirname(__FILE__), "neocities_red", "services", "common", "pizza")
+end

--- a/lib/neocities_red.rb
+++ b/lib/neocities_red.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require File.join(File.dirname(__FILE__), "neocities_red", "version")
+require File.join(File.dirname(__FILE__), "neocities_red", "errors")
 require File.join(File.dirname(__FILE__), "neocities_red", "client")
 require File.join(File.dirname(__FILE__), "neocities_red", "cli_display")
 require File.join(File.dirname(__FILE__), "neocities_red", "cli")
@@ -14,4 +15,6 @@ require File.join(File.dirname(__FILE__), "neocities_red", "services", "site", "
 require File.join(File.dirname(__FILE__), "neocities_red", "services", "site", "informer")
 require File.join(File.dirname(__FILE__), "neocities_red", "services", "site", "exporter")
 require File.join(File.dirname(__FILE__), "neocities_red", "services", "site", "pusher")
+require File.join(File.dirname(__FILE__), "neocities_red", "services", "common", "exclusions")
+require File.join(File.dirname(__FILE__), "neocities_red", "services", "common", "worker_pool")
 require File.join(File.dirname(__FILE__), "neocities_red", "services", "common", "pizza")

--- a/lib/neocities_red/cli.rb
+++ b/lib/neocities_red/cli.rb
@@ -9,6 +9,21 @@ require "thor"
 require_relative "cli_display"
 
 module NeocitiesRed
+  # Thor-based command-line interface for the NeocitiesRed gem.
+  #
+  # Provides subcommands for managing a Neocities site: push, upload,
+  # delete, diff, list, info, pull, purge, logout, and pizza.
+  #
+  # Authentication is handled lazily — the first command that requires
+  # an API connection will prompt for credentials (or read from config/env).
+  #
+  # @example Running from shell
+  #   $ neocities-red push .
+  #   $ neocities-red list -a
+  #   $ neocities-red diff --ignore-dotfiles
+  #
+  # @see NeocitiesRed::Client Underlying API client
+  # @see NeocitiesRed::CliDisplay Terminal output helper
   class CLI < Thor
     package_name "neocities-red"
     default_task :help
@@ -23,6 +38,12 @@ module NeocitiesRed
     method_option :help, aliases: "-h", type: :boolean
     method_option :ignore_dotfiles, type: :boolean, default: false
     method_option :exclude, aliases: "-e", type: :string, repeatable: true, default: []
+
+    # Compares local files with the remote Neocities site and displays
+    # added, modified, and removed files.
+    #
+    # @param path [String] local directory path to compare (defaults to current directory)
+    # @return [void]
     def diff(path = ".")
       return display_help_for("diff") if help_requested?(options[:help], path)
 
@@ -42,6 +63,11 @@ module NeocitiesRed
 
     desc "delete PATH [PATH ...]", "Delete files on your Neocities site"
     method_option :help, aliases: "-h", type: :boolean
+
+    # Deletes one or more files from the remote Neocities site.
+    #
+    # @param paths [Array<String>] remote file paths to delete
+    # @return [void]
     def delete(*paths)
       return display_help_for("delete") if paths.empty? || help_requested?(options[:help], paths)
 
@@ -52,6 +78,12 @@ module NeocitiesRed
     desc "logout", "Remove the site api key from the config"
     method_option :help, aliases: "-h", type: :boolean
     method_option :yes, aliases: "-y", type: :boolean, default: false
+
+    # Removes the stored API key from the local config file.
+    #
+    # Requires the +--yes+ / +-y+ flag to confirm the action.
+    #
+    # @return [void]
     def logout
       return display_help_for("logout") if help_requested?(options[:help]) || !options[:yes]
 
@@ -61,6 +93,13 @@ module NeocitiesRed
 
     desc "info [SITENAME]", "Get site info"
     method_option :help, aliases: "-h", type: :boolean
+
+    # Displays information and statistics for a Neocities site.
+    #
+    # @param sitename [String, nil] site name to query; defaults to the
+    #   currently authenticated site when omitted
+    # @return [void]
+    # @raise [NeocitiesRed::APIError] if the API request fails
     def info(sitename = nil)
       return display_help_for("info") if help_requested?(options[:help], sitename)
 
@@ -75,6 +114,13 @@ module NeocitiesRed
     method_option :help, aliases: "-h", type: :boolean
     method_option :detail, aliases: "-d", type: :boolean, default: false
     method_option :all, aliases: "-a", type: :boolean, default: false
+
+    # Lists files on the remote Neocities site.
+    #
+    # @param path [String, nil] remote directory path to list (nil for root,
+    #   or when +--all+ is used)
+    # @return [void]
+    # @raise [NeocitiesRed::APIError] if the API request fails
     def list(path = nil)
       if help_requested?(options[:help], path) || (path.nil? && options[:all].nil? && options[:detail].nil?)
         display_help_for("list")
@@ -96,6 +142,18 @@ module NeocitiesRed
     method_option :dry_run, type: :boolean, default: false
     method_option :prune, type: :boolean, default: false
     method_option :optimized, type: :boolean, default: false
+
+    # Recursively uploads a local directory to the Neocities site.
+    #
+    # Supports +--no-gitignore+ to ignore .gitignore rules,
+    # +--ignore-dotfiles+ to skip dot-prefixed files,
+    # +--exclude+ to skip specific paths, +--dry-run+ to preview changes,
+    # +--prune+ to delete remote files not present locally, and
+    # +--optimized+ to skip files whose SHA1 hash matches the server.
+    #
+    # @param root [String, nil] local directory path to upload
+    # @return [void]
+    # @raise [ArgumentError] if the path does not exist or is not a directory
     def push(root = nil)
       return display_help_for("push") if help_requested?(options[:help], root)
 
@@ -120,6 +178,15 @@ module NeocitiesRed
 
     desc "upload LOCAL_PATH [REMOTE_PATH]", "Upload a file/folder to your Neocities site"
     method_option :help, aliases: "-h", type: :boolean
+
+    # Uploads a single file or an entire folder to the Neocities site.
+    #
+    # When +LOCAL_PATH+ is a file, uploads it directly.
+    # When it is a directory, uploads all files within it in parallel.
+    #
+    # @param local_path [String, nil] local file or directory path
+    # @param remote_path [String, nil] remote destination; defaults to the basename of +local_path+
+    # @return [void]
     def upload(local_path = nil, remote_path = nil)
       return display_help_for("upload") if help_requested?(options[:help], [local_path, remote_path])
       return display_help_for("upload") if local_path.nil?
@@ -138,6 +205,15 @@ module NeocitiesRed
     desc "pull", "Get the most recent version of files from your site"
     method_option :help, aliases: "-h", type: :boolean
     method_option :quiet, aliases: "-q", type: :boolean, default: false
+
+    # Downloads the latest version of site files from the remote Neocities site.
+    #
+    # Skips files that haven't changed since the last pull (based on stored
+    # timestamp and working directory). Use +--quiet+ to suppress per-file
+    # output and show a spinner instead.
+    #
+    # @return [void]
+    # @raise [StandardError] on network or API errors
     def pull
       return display_help_for("pull") if help_requested?(options[:help])
 
@@ -156,6 +232,13 @@ module NeocitiesRed
     desc "purge", "Delete everything from your site (development only)"
     method_option :yes, aliases: "-y", type: :boolean, default: false
     method_option :dry_run, type: :boolean, default: false
+
+    # Deletes all files from the Neocities site.
+    #
+    # Requires the +--yes+ / +-y+ flag to confirm the destructive action.
+    # Use +--dry-run+ to preview what would be deleted without changes.
+    #
+    # @return [void]
     def purge
       return display_help_for("purge") unless options[:yes]
 
@@ -179,10 +262,19 @@ module NeocitiesRed
     end
 
     desc "pizza", "Order a free pizza"
+
+    # Easter egg — displays a humorous pizza-related excuse.
+    #
+    # @return [void]
     def pizza
       display_help_for(__method__)
     end
 
+    # Returns the platform-specific application config directory path.
+    #
+    # @param name [String] application name (e.g. "neocities")
+    # @return [String, nil] full path to the config directory, or nil if
+    #   the platform cannot be determined
     def self.app_config_path(name)
       platform = case RUBY_PLATFORM
                  when /cygwin|mswin|mingw|bccwin|wince|emx|win32/
@@ -223,6 +315,12 @@ module NeocitiesRed
     end
 
     desc "help [COMMAND]", "Show help for a command"
+
+    # Displays help for a specific command or the general help screen.
+    #
+    # @param command [String, nil] command name to show help for;
+    #   nil displays the main help screen
+    # @return [void]
     def help(command = nil)
       return display.display_help_and_exit if command.nil?
 
@@ -233,6 +331,10 @@ module NeocitiesRed
     end
 
     desc "version", "Display neocities-red version"
+
+    # Prints the current gem version to stdout.
+    #
+    # @return [void]
     def version
       display.say NeocitiesRed::VERSION
     end
@@ -240,18 +342,30 @@ module NeocitiesRed
     no_commands do
       alias_method :display_help_for, :help
 
+      # Returns the initialized {CliDisplay} instance.
+      #
+      # @return [NeocitiesRed::CliDisplay]
       def display
         @display ||= NeocitiesRed::CliDisplay.new
       end
 
+      # Returns the initialized TTY::Prompt instance for interactive input.
+      #
+      # @return [TTY::Prompt]
       def prompt
         @prompt ||= TTY::Prompt.new
       end
 
+      # Returns the full path to the application config file.
+      #
+      # @return [String] path to +config.json+ inside the platform config directory
       def app_config_path
         @app_config_path ||= File.join(self.class.app_config_path("neocities"), "config.json")
       end
 
+      # Reads and parses the JSON config file from disk.
+      #
+      # @return [Hash, nil] parsed config hash, or nil if the file does not exist
       def read_config
         file = File.read(app_config_path)
         JSON.parse(file)
@@ -259,6 +373,12 @@ module NeocitiesRed
         nil
       end
 
+      # Lazily initializes and returns an authenticated {Client} instance.
+      #
+      # Reads the API key from (in order): CLI option, environment variable,
+      # or stored config. If no key is found, triggers interactive login.
+      #
+      # @return [NeocitiesRed::Client]
       def ensure_client!
         return @client if @client
 
@@ -278,6 +398,13 @@ module NeocitiesRed
         @client
       end
 
+      # Prompts the user for credentials, obtains an API key, and stores it.
+      #
+      # Saves the API key and sitename to the local config file with
+      # restricted permissions (0600).
+      #
+      # @return [void]
+      # @raise [Thor::Error] if the API key cannot be obtained
       def authenticate_and_persist_key!
         display.display_login_prompt
 
@@ -304,11 +431,19 @@ module NeocitiesRed
         @client = NeocitiesRed::Client.new(api_key: @api_key)
       end
 
+      # Writes the config hash to disk as JSON and restricts file permissions.
+      #
+      # @param conf [Hash] configuration data to persist
+      # @return [void]
       def persist_config(conf)
         File.write(app_config_path, conf.to_json)
         FileUtils.chmod(0o600, app_config_path)
       end
 
+      # Checks if the given value contains a help flag.
+      #
+      # @param value [String, Array<String>, nil] value to inspect
+      # @return [Boolean] true if the value is or contains "-h", "--help", or "help"
       def help_requested_for?(value)
         case value
         when Array
@@ -318,6 +453,11 @@ module NeocitiesRed
         end
       end
 
+      # Determines if help was requested via the +--help+ option or the value.
+      #
+      # @param help_option [Boolean, nil] the Thor +--help+ option value
+      # @param value [String, Array<String>, nil] the positional argument to check
+      # @return [Boolean]
       def help_requested?(help_option, value = nil)
         help_option || (value && help_requested_for?(value))
       end

--- a/lib/neocities_red/cli.rb
+++ b/lib/neocities_red/cli.rb
@@ -27,7 +27,7 @@ module NeocitiesRed
       return display_help_for("diff") if help_requested?(options[:help], path)
 
       client = ensure_client!
-      exclude = build_diff_exclusions(path, Array(options[:exclude]))
+      exclude = Services::Common::Exclusions.build(Array(options[:exclude]), base_path: path)
 
       added, modified, removed = Services::Site::Differencer.new(
         client,
@@ -46,7 +46,7 @@ module NeocitiesRed
       return display_help_for("delete") if paths.empty? || help_requested?(options[:help], paths)
 
       client = ensure_client!
-      paths.each { |path| Services::File::Remover.new(client, path).remove }
+      paths.each { |path| Services::File::Remover.new(client, path, display: display).remove }
     end
 
     desc "logout", "Remove the site api key from the config"
@@ -83,7 +83,9 @@ module NeocitiesRed
 
       client = ensure_client!
       path = nil if options[:all]
-      display.say Services::File::List.new(client, path, options[:detail]).show
+      display.say Services::File::List.new(client, path, options[:detail], display: display).show
+    rescue NeocitiesRed::APIError => e
+      display.display_response(e)
     end
 
     desc "push PATH", "Recursively upload a local directory to your Neocities site"
@@ -125,9 +127,9 @@ module NeocitiesRed
       client = ensure_client!
       dest = remote_path || File.basename(local_path)
       if File.file?(local_path)
-        Services::File::Uploader.new(client, local_path, dest).upload
+        Services::File::Uploader.new(client, local_path, dest, display: display).upload
       elsif File.directory?(local_path)
-        folder_uploader = Services::File::FolderUploader.new(client, local_path, dest)
+        folder_uploader = Services::File::FolderUploader.new(client, local_path, dest, display: display)
         files_list = folder_uploader.files
         folder_uploader.upload(files_list)
       end
@@ -145,8 +147,10 @@ module NeocitiesRed
       last_pull_time = data.dig("LAST_PULL", "time")
       last_pull_loc = data.dig("LAST_PULL", "loc")
 
-      Services::Site::Exporter.new(client, @sitename, data, app_config_path)
+      Services::Site::Exporter.new(client, @sitename, data, app_config_path, display: display)
                               .export(quiet: options[:quiet], last_pull_time: last_pull_time, last_pull_loc: last_pull_loc)
+    rescue StandardError => e
+      display.display_response(e)
     end
 
     desc "purge", "Delete everything from your site (development only)"
@@ -303,31 +307,6 @@ module NeocitiesRed
       def persist_config(conf)
         File.write(app_config_path, conf.to_json)
         FileUtils.chmod(0o600, app_config_path)
-      end
-
-      def build_diff_exclusions(base_path, excluded_entries)
-        base = Pathname.new(base_path).expand_path
-        excludes = []
-
-        excluded_entries.each do |entry|
-          target = Pathname.new(entry).expand_path
-          next unless target.exist?
-
-          filepath = target.relative_path_from(base).to_s
-
-          if File.file?(target)
-            excludes << filepath
-          elsif File.directory?(target)
-            excludes.concat(
-              Dir.glob(File.join(target, "**", "*"), File::FNM_DOTMATCH).map do |path|
-                Pathname.new(path).expand_path.relative_path_from(base).to_s
-              end
-            )
-            excludes << filepath
-          end
-        end
-
-        excludes
       end
 
       def help_requested_for?(value)

--- a/lib/neocities_red/cli.rb
+++ b/lib/neocities_red/cli.rb
@@ -384,7 +384,6 @@ module NeocitiesRed
 
         config = read_config
         @sitename = config && config["SITENAME"]
-        @last_pull = config && config["LAST_PULL"]
 
         @api_key = options[:api_key] || ENV.fetch("NEOCITIES_API_KEY", nil)
         @api_key ||= config && config["API_KEY"]&.strip

--- a/lib/neocities_red/cli.rb
+++ b/lib/neocities_red/cli.rb
@@ -151,10 +151,12 @@ module NeocitiesRed
 
     desc "purge", "Delete everything from your site (development only)"
     method_option :yes, aliases: "-y", type: :boolean, default: false
+    method_option :dry_run, type: :boolean, default: false
     def purge
       return display_help_for("purge") unless options[:yes]
 
       client = ensure_client!
+      display.display_dry_run_notice if options[:dry_run]
       resp = client.list
       deleted_dirs = []
       resp[:files].sort_by { |f| f[:is_directory] ? 0 : 1 }.each do |file|
@@ -293,9 +295,14 @@ module NeocitiesRed
         }
 
         FileUtils.mkdir_p(Pathname(app_config_path).dirname)
-        File.write(app_config_path, conf.to_json)
+        persist_config(conf)
         display.display_api_key_saved(@sitename, app_config_path)
         @client = NeocitiesRed::Client.new(api_key: @api_key)
+      end
+
+      def persist_config(conf)
+        File.write(app_config_path, conf.to_json)
+        FileUtils.chmod(0o600, app_config_path)
       end
 
       def build_diff_exclusions(base_path, excluded_entries)

--- a/lib/neocities_red/cli_display.rb
+++ b/lib/neocities_red/cli_display.rb
@@ -89,8 +89,52 @@ module NeocitiesRed
       say "Not pushing .gitignore entries (--no-gitignore to disable)"
     end
 
+    def display_upload_progress(path, remote_path)
+      @io.print @pastel.bold("Uploading #{path} to #{remote_path} ... ")
+    end
+
+    def display_upload_success
+      @io.print "#{@pastel.green.bold('SUCCESS')}\n"
+    end
+
+    def display_upload_exists
+      @io.print "#{@pastel.yellow.bold('EXISTS')}\n"
+    end
+
+    def display_skip_directory(path)
+      say @pastel.bold("#{path} is a directory, skipping")
+    end
+
+    def display_skip_file(path)
+      say @pastel.bold("#{path} is not a directory, skipping")
+    end
+
     def display_upload_complete
       say "All files uploaded."
+    end
+
+    def display_list_table(table)
+      say table
+    end
+
+    def display_pull_progress(path)
+      @io.print @pastel.bold("Pulling #{path} ... ")
+    end
+
+    def display_pull_no_updates
+      @io.print "#{@pastel.yellow.bold('NO NEW UPDATES')}\n"
+    end
+
+    def display_pull_success
+      @io.print "#{@pastel.green.bold('SUCCESS')}\n"
+    end
+
+    def display_pull_failure
+      @io.print "#{@pastel.red.bold('FAIL')}\n"
+    end
+
+    def display_pull_stats(success_loaded, total_time)
+      say @pastel.green "\nSuccessfully fetched #{success_loaded} files in #{total_time.round(2)} seconds"
     end
 
     def display_pizza_help_and_exit

--- a/lib/neocities_red/cli_display.rb
+++ b/lib/neocities_red/cli_display.rb
@@ -244,7 +244,9 @@ module NeocitiesRed
 
         #{@pastel.dim 'Examples:'}
 
-        #{@pastel.green '$ neocities-red purge -y'}
+        #{@pastel.green '$ neocities-red purge -y'}                Delete all files from your site
+
+        #{@pastel.green '$ neocities-red purge -y --dry-run'}      Show what would be deleted
       HERE
       exit
     end

--- a/lib/neocities_red/cli_display.rb
+++ b/lib/neocities_red/cli_display.rb
@@ -112,14 +112,6 @@ module NeocitiesRed
       say "The api key for #{@pastel.bold(sitename)} has been stored in #{@pastel.bold(path)}."
     end
 
-    # Displays an unknown CLI option error.
-    #
-    # @param option [String] the unrecognized option
-    # @return [void]
-    def display_unknown_option(option)
-      say @pastel.red.bold("Unknown option: #{option.inspect}")
-    end
-
     # Displays a logout success message.
     #
     # @return [void]

--- a/lib/neocities_red/cli_display.rb
+++ b/lib/neocities_red/cli_display.rb
@@ -3,19 +3,54 @@
 require "pastel"
 
 module NeocitiesRed
+  # Terminal output helper for the CLI.
+  #
+  # Wraps all user-facing output — progress indicators, success/error
+  # messages, help screens, and the ASCII art banner. Uses Pastel for
+  # colored and styled terminal output.
+  #
+  # Every +display_*+ method prints to stdout and may call +exit+
+  # (for help screens). Non-help methods return +nil+.
+  #
+  # @example
+  #   display = NeocitiesRed::CliDisplay.new
+  #   display.display_response(result: "success", message: "Uploaded!")
+  #
+  # @see NeocitiesRed::CLI Uses this class for all terminal output
   class CliDisplay
+    # @return [Array<String>] Mouth sprites for the Penelope banner cat.
     PENELOPE_MOUTHS = %w[^ o ~ - v U].freeze
+
+    # @return [Array<String>] Eye sprites for the Penelope banner cat.
     PENELOPE_EYES = %w[o ~ O].freeze
 
+    # Creates a new display instance.
+    #
+    # @param io [IO] output stream (defaults to +$stdout+; inject a
+    #   StringIO for testing)
     def initialize(io: $stdout)
       @io = io
       @pastel = Pastel.new(eachline: "\n")
     end
 
+    # Prints a message followed by a newline.
+    #
+    # @param message [String] text to print
+    # @return [void]
     def say(message = "")
       @io.puts(message)
     end
 
+    # Displays an API response with appropriate coloring.
+    #
+    # Handles three response shapes:
+    # - +Exception+ — prints the error message in red and exits
+    # - +:result == "success"+ — prints in green
+    # - +:result == "error" && :error_type == "file_exists"+ — prints in yellow
+    # - All other errors — prints in red
+    #
+    # @param resp [Hash, Exception] API response or exception
+    # @return [void]
     def display_response(resp)
       if resp.is_a?(Exception)
         say "#{@pastel.red.bold('ERROR:')} #{resp.detailed_message}"
@@ -35,6 +70,15 @@ module NeocitiesRed
       end
     end
 
+    # Displays the results of a diff operation.
+    #
+    # Prints removed files in red, modified files in yellow,
+    # and added files in green. Each section is only shown if non-empty.
+    #
+    # @param added [Array<String>] local files not present on the server
+    # @param modified [Array<String>] files whose SHA1 hash differs
+    # @param removed [Array<String>] server files not present locally
+    # @return [void]
     def display_diff_results(added:, modified:, removed:)
       if removed.any?
         say @pastel.bold.red("Removed files")
@@ -52,96 +96,179 @@ module NeocitiesRed
       say added
     end
 
+    # Prints the interactive login prompt message.
+    #
+    # @return [void]
     def display_login_prompt
       say "Please login to get your API key:"
     end
 
+    # Confirms that the API key has been saved to disk.
+    #
+    # @param sitename [String] the site name
+    # @param path [String] the config file path where the key was stored
+    # @return [void]
     def display_api_key_saved(sitename, path)
       say "The api key for #{@pastel.bold(sitename)} has been stored in #{@pastel.bold(path)}."
     end
 
+    # Displays an unknown CLI option error.
+    #
+    # @param option [String] the unrecognized option
+    # @return [void]
     def display_unknown_option(option)
       say @pastel.red.bold("Unknown option: #{option.inspect}")
     end
 
+    # Displays a logout success message.
+    #
+    # @return [void]
     def display_logout_success
       say @pastel.bold("Your api key has been removed.")
     end
 
+    # Displays a notice that the current operation is a dry run.
+    #
+    # @return [void]
     def display_dry_run_notice
       say @pastel.green.bold("Doing a dry run, not actually pushing anything")
     end
 
+    # Prints the file deletion progress indicator (without newline).
+    #
+    # @param path [String] remote file path being deleted
+    # @return [void]
     def display_delete_progress(path)
       @io.print @pastel.bold("Deleting #{path} ... ")
     end
 
+    # Prints a green "SUCCESS" after a file is deleted.
+    #
+    # @return [void]
     def display_delete_success
       @io.print "#{@pastel.green.bold('SUCCESS')}\n"
     end
 
+    # Prints an error response that occurred during file deletion.
+    #
+    # @param resp [Hash] the API error response
+    # @return [void]
     def display_delete_error(resp)
       @io.print "\n"
       display_response(resp)
     end
 
+    # Displays a hint that .gitignore entries are being excluded.
+    #
+    # @return [void]
     def display_gitignore_hint
       say "Not pushing .gitignore entries (--no-gitignore to disable)"
     end
 
+    # Prints the file upload progress indicator (without newline).
+    #
+    # @param path [String] local file path being uploaded
+    # @param remote_path [String] remote destination path
+    # @return [void]
     def display_upload_progress(path, remote_path)
       @io.print @pastel.bold("Uploading #{path} to #{remote_path} ... ")
     end
 
+    # Prints a green "SUCCESS" after a file is uploaded.
+    #
+    # @return [void]
     def display_upload_success
       @io.print "#{@pastel.green.bold('SUCCESS')}\n"
     end
 
+    # Prints a yellow "EXISTS" when the uploaded file already matches remotely.
+    #
+    # @return [void]
     def display_upload_exists
       @io.print "#{@pastel.yellow.bold('EXISTS')}\n"
     end
 
+    # Displays a message that a directory path is being skipped.
+    #
+    # @param path [String] the directory path that was skipped
+    # @return [void]
     def display_skip_directory(path)
       say @pastel.bold("#{path} is a directory, skipping")
     end
 
+    # Displays a message that a non-directory path is being skipped
+    # (during folder upload).
+    #
+    # @param path [String] the file path that was skipped
+    # @return [void]
     def display_skip_file(path)
       say @pastel.bold("#{path} is not a directory, skipping")
     end
 
+    # Displays a message that all file uploads are complete.
+    #
+    # @return [void]
     def display_upload_complete
       say "All files uploaded."
     end
 
+    # Renders a TTY::Table to the output stream.
+    #
+    # @param table [TTY::Table] the table to display
+    # @return [void]
     def display_list_table(table)
       say table
     end
 
+    # Prints the file pull progress indicator (without newline).
+    #
+    # @param path [String] remote file path being pulled
+    # @return [void]
     def display_pull_progress(path)
       @io.print @pastel.bold("Pulling #{path} ... ")
     end
 
+    # Prints "NO NEW UPDATES" in yellow for files skipped during pull.
+    #
+    # @return [void]
     def display_pull_no_updates
       @io.print "#{@pastel.yellow.bold('NO NEW UPDATES')}\n"
     end
 
+    # Prints a green "SUCCESS" after a file is pulled.
+    #
+    # @return [void]
     def display_pull_success
       @io.print "#{@pastel.green.bold('SUCCESS')}\n"
     end
 
+    # Prints a red "FAIL" when a file pull fails.
+    #
+    # @return [void]
     def display_pull_failure
       @io.print "#{@pastel.red.bold('FAIL')}\n"
     end
 
+    # Displays a summary of pull statistics.
+    #
+    # @param success_loaded [Integer] number of files successfully downloaded
+    # @param total_time [Float] total elapsed time in seconds
+    # @return [void]
     def display_pull_stats(success_loaded, total_time)
       say @pastel.green "\nSuccessfully fetched #{success_loaded} files in #{total_time.round(2)} seconds"
     end
 
+    # Displays the pizza easter egg help screen and exits.
+    #
+    # @return [void]
     def display_pizza_help_and_exit
       say Services::Common::Pizza.new.make_order
       exit
     end
 
+    # Displays the help screen for the +list+ command and exits.
+    #
+    # @return [void]
     def display_list_help_and_exit
       display_banner
 
@@ -159,6 +286,9 @@ module NeocitiesRed
       exit
     end
 
+    # Displays the help screen for the +delete+ command and exits.
+    #
+    # @return [void]
     def display_delete_help_and_exit
       display_banner
 
@@ -176,6 +306,9 @@ module NeocitiesRed
       exit
     end
 
+    # Displays the help screen for the +upload+ command and exits.
+    #
+    # @return [void]
     def display_upload_help_and_exit
       display_banner
 
@@ -201,6 +334,9 @@ module NeocitiesRed
       exit
     end
 
+    # Displays the help screen for the +pull+ command and exits.
+    #
+    # @return [void]
     def display_pull_help_and_exit
       display_banner
 
@@ -210,6 +346,9 @@ module NeocitiesRed
       exit
     end
 
+    # Displays the help screen for the +push+ command and exits.
+    #
+    # @return [void]
     def display_push_help_and_exit
       display_banner
 
@@ -235,6 +374,9 @@ module NeocitiesRed
       exit
     end
 
+    # Displays the help screen for the +diff+ command and exits.
+    #
+    # @return [void]
     def display_diff_help_and_exit
       display_banner
 
@@ -254,6 +396,9 @@ module NeocitiesRed
       exit
     end
 
+    # Displays the help screen for the +info+ command and exits.
+    #
+    # @return [void]
     def display_info_help_and_exit
       display_banner
 
@@ -267,6 +412,9 @@ module NeocitiesRed
       exit
     end
 
+    # Displays the help screen for the +logout+ command and exits.
+    #
+    # @return [void]
     def display_logout_help_and_exit
       display_banner
 
@@ -280,6 +428,9 @@ module NeocitiesRed
       exit
     end
 
+    # Displays the help screen for the +purge+ command and exits.
+    #
+    # @return [void]
     def display_purge_help_and_exit
       display_banner
 
@@ -295,6 +446,9 @@ module NeocitiesRed
       exit
     end
 
+    # Renders the ASCII art banner with a random Penelope cat face.
+    #
+    # @return [void]
     def display_banner
       say <<~HERE
 
@@ -305,6 +459,9 @@ module NeocitiesRed
       HERE
     end
 
+    # Displays the main help screen listing all available subcommands and exits.
+    #
+    # @return [void]
     def display_help_and_exit
       display_banner
       say <<~HERE

--- a/lib/neocities_red/client.rb
+++ b/lib/neocities_red/client.rb
@@ -125,11 +125,7 @@ module NeocitiesRed
       rpath = remote_path || path.basename
       res = upload_hash(rpath.to_s, Digest::SHA1.file(path.to_s).hexdigest)
 
-      file_exists_remotely = if res[:files]
-                               res[:files][rpath.to_s.to_sym] == true || res[:files][rpath.to_s] == true
-                             else
-                               false
-                             end
+      file_exists_remotely = res[:files] ? res[:files][rpath.to_s.to_sym] == true : false
 
       if file_exists_remotely
         {

--- a/lib/neocities_red/client.rb
+++ b/lib/neocities_red/client.rb
@@ -11,9 +11,7 @@ require "json"
 require "pathname"
 require "uri"
 require "digest"
-require "pastel"
 require "date"
-require "whirly"
 
 require "faraday"
 require "faraday/retry"
@@ -27,7 +25,6 @@ module NeocitiesRed
     def initialize(opts = {})
       @uri = URI.parse API_URI
       @opts = opts
-      @pastel = Pastel.new eachline: "\n"
       @conn = Faraday.new(@uri) do |conn|
         conn.options.timeout = 30
         conn.options.open_timeout = 10
@@ -61,75 +58,6 @@ module NeocitiesRed
 
     def list(path = nil)
       get "list", path: path
-    end
-
-    # TODO: refactor
-    def pull(sitename, last_pull_time = nil, last_pull_loc = nil, quiet: true)
-      site_info = info(sitename)
-
-      raise ArgumentError, site_info[:message] if site_info[:result] == "error"
-
-      info_data = site_info[:info]
-
-      domain =
-        if info_data[:domain].to_s.empty?
-          "https://#{sitename}.neocities.org/"
-        else
-          "https://#{info_data[:domain]}/"
-        end
-
-      # start stats
-      success_loaded = 0
-      start_time = Time.now
-      curr_dir = Dir.pwd
-
-      # get list of files
-      resp = list
-
-      raise ArgumentError, resp[:message] if resp[:result] == "error"
-
-      # fetch each file
-      uri_parser = URI::Parser.new
-      resp[:files].each do |file|
-        if file[:is_directory]
-          FileUtils.mkdir_p file[:path].to_s
-        else
-          print @pastel.bold("Pulling #{file[:path]} ... ") unless quiet
-
-          if last_pull_time &&
-             last_pull_loc &&
-             Time.parse(file[:updated_at]) <= Time.parse(last_pull_time) &&
-             last_pull_loc == curr_dir &&
-             File.exist?(file[:path]) # case when user deletes file
-
-            # case when file hasn't been updated since last
-            print "#{@pastel.yellow.bold 'NO NEW UPDATES'}\n" unless quiet
-
-            next
-          end
-
-          pathtotry = uri_parser.escape(domain + file[:path])
-          fileconts = @conn.get pathtotry
-
-          if fileconts.status == 200
-            print "#{@pastel.green.bold 'SUCCESS'}\n" unless quiet
-            success_loaded += 1
-
-            File.write(file[:path].to_s, fileconts.body)
-          elsif !quiet
-            print "#{@pastel.red.bold 'FAIL'}\n"
-          end
-        end
-      end
-
-      # calculate time command took
-      total_time = Time.now - start_time
-
-      # stop the spinner, if there is one
-      Whirly.stop if quiet
-
-      # display stats
-      puts @pastel.green "\nSuccessfully fetched #{success_loaded} files in #{total_time.round(2)} seconds"
     end
 
     def key
@@ -188,6 +116,10 @@ module NeocitiesRed
       resp = @conn.get(uri)
 
       JSON.parse resp.body, symbolize_names: true
+    end
+
+    def download(url)
+      @conn.get(url)
     end
 
     def post(path, args = {})

--- a/lib/neocities_red/client.rb
+++ b/lib/neocities_red/client.rb
@@ -19,9 +19,32 @@ require "faraday/multipart"
 require "faraday/follow_redirects"
 
 module NeocitiesRed
+  # HTTP client for the Neocities API.
+  #
+  # Wraps all API interactions — listing, uploading, deleting, and querying
+  # site information. Supports both API-key (Bearer) and basic-auth
+  # (sitename/password) authentication.
+  #
+  # Retries transient failures (429, 5xx) automatically via Faraday::Retry.
+  #
+  # @example API key authentication
+  #   client = NeocitiesRed::Client.new(api_key: "your-api-key")
+  #   client.list
+  #
+  # @example Basic auth authentication
+  #   client = NeocitiesRed::Client.new(sitename: "my-site", password: "secret")
+  #   client.list
   class Client
+    # @return [String] Base URL for the Neocities REST API.
     API_URI = "https://neocities.org/api/"
 
+    # Creates a new API client.
+    #
+    # @param opts [Hash] authentication options
+    # @option opts [String] :api_key Bearer token for API-key authentication
+    # @option opts [String] :sitename site name for basic-auth (requires +:password+)
+    # @option opts [String] :password site password for basic-auth (requires +:sitename+)
+    # @raise [ArgumentError] if neither +:api_key+ nor (+:sitename+ and +:password+) are provided
     def initialize(opts = {})
       @uri = URI.parse API_URI
       @opts = opts
@@ -56,18 +79,45 @@ module NeocitiesRed
       end
     end
 
+    # Lists files on the remote Neocities site.
+    #
+    # @param path [String, nil] directory path to list (nil for root)
+    # @return [Hash] parsed API response containing +:files+ array
     def list(path = nil)
       get "list", path: path
     end
 
+    # Retrieves the API key for the currently authenticated user.
+    #
+    # Only meaningful when authenticated via basic-auth (sitename/password).
+    #
+    # @return [Hash] parsed API response containing +:api_key+
     def key
       get "key"
     end
 
+    # Checks whether the remote file matches the given SHA1 hash.
+    #
+    # Used by {#upload} to skip uploading files that haven't changed.
+    #
+    # @param remote_path [String] remote file path to check
+    # @param sha1_hash [String] hex-encoded SHA1 hash of the local file
+    # @return [Hash] parsed API response with +:files+ mapping paths to booleans
     def upload_hash(remote_path, sha1_hash)
       post "upload_hash", remote_path => sha1_hash
     end
 
+    # Uploads a single file to the Neocities site.
+    #
+    # Computes the SHA1 hash of the local file and compares it with the
+    # remote version. If the file already exists remotely with the same
+    # hash, the upload is skipped and an "exists" response is returned.
+    #
+    # @param path [String, Pathname] local file path to upload
+    # @param remote_path [String, nil] remote destination path; defaults to the basename of +path+
+    # @param dry_run [Boolean] when true, simulates the upload without sending data
+    # @return [Hash] API response with +:result+ key ("success", "error", or "file_exists")
+    # @raise [ArgumentError] if the local file does not exist
     def upload(path, remote_path = nil, dry_run: false)
       path = Pathname path
       raise ArgumentError, "#{path} does not exist." unless path.exist?
@@ -96,20 +146,40 @@ module NeocitiesRed
       end
     end
 
+    # Deletes one or more remote files, with optional dry-run support.
+    #
+    # @param paths [Array<String>] remote file paths to delete
+    # @param dry_run [Boolean] when true, simulates the deletion
+    # @return [Hash] API response with +:result+ key
     def delete_wrapper_with_dry_run(paths, dry_run: false)
       return { result: "success" } if dry_run
 
       delete(paths)
     end
 
+    # Deletes one or more files from the remote Neocities site.
+    #
+    # @param paths [Array<String>] remote file paths to delete
+    # @return [Hash] parsed API response
     def delete(*paths)
       post "delete", "filenames" => paths
     end
 
+    # Retrieves information and statistics for a Neocities site.
+    #
+    # @param sitename [String] the site name to query
+    # @return [Hash] parsed API response containing +:info+ hash with
+    #   site metadata (domain, created_at, last_updated, bandwidth, etc.)
+    # @raise [NeocitiesRed::APIError] if the API returns an error
     def info(sitename)
       get "info", sitename: sitename
     end
 
+    # Performs an HTTP GET request to the Neocities API.
+    #
+    # @param path [String] API endpoint path (e.g. "list", "info")
+    # @param params [Hash] query parameters
+    # @return [Hash] parsed JSON response with symbolized keys
     def get(path, params = {})
       uri = @uri + path
       uri.query = URI.encode_www_form params
@@ -118,10 +188,19 @@ module NeocitiesRed
       JSON.parse resp.body, symbolize_names: true
     end
 
+    # Downloads a file from a URL.
+    #
+    # @param url [String] full URL to download
+    # @return [Faraday::Response] raw Faraday response object
     def download(url)
       @conn.get(url)
     end
 
+    # Performs an HTTP POST request to the Neocities API.
+    #
+    # @param path [String] API endpoint path (e.g. "upload", "delete")
+    # @param args [Hash] request body parameters
+    # @return [Hash] parsed JSON response with symbolized keys
     def post(path, args = {})
       uri = @uri + path
       resp = @conn.post(uri, args)

--- a/lib/neocities_red/errors.rb
+++ b/lib/neocities_red/errors.rb
@@ -1,11 +1,26 @@
 # frozen_string_literal: true
 
 module NeocitiesRed
+  # Base error class for all NeocitiesRed exceptions.
+  #
+  # @abstract Subclass this for domain-specific errors.
   class Error < StandardError; end
 
+  # Raised when authentication with the Neocities API fails.
+  #
+  # This may occur due to invalid credentials, an expired API key,
+  # or failure to obtain an API key during interactive login.
   class AuthenticationError < Error; end
 
+  # Raised when the Neocities API returns a non-success response.
+  #
+  # Wraps error messages from the remote API so callers can inspect
+  # the +:message+ and +:error_type+ fields from the response.
   class APIError < Error; end
 
+  # Raised when a referenced file does not exist on the local filesystem.
+  #
+  # Typically raised by upload services when the source file
+  # cannot be found at the given path.
   class FileNotFoundError < Error; end
 end

--- a/lib/neocities_red/errors.rb
+++ b/lib/neocities_red/errors.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module NeocitiesRed
+  class Error < StandardError; end
+
+  class AuthenticationError < Error; end
+
+  class APIError < Error; end
+
+  class FileNotFoundError < Error; end
+end

--- a/lib/neocities_red/errors.rb
+++ b/lib/neocities_red/errors.rb
@@ -6,12 +6,6 @@ module NeocitiesRed
   # @abstract Subclass this for domain-specific errors.
   class Error < StandardError; end
 
-  # Raised when authentication with the Neocities API fails.
-  #
-  # This may occur due to invalid credentials, an expired API key,
-  # or failure to obtain an API key during interactive login.
-  class AuthenticationError < Error; end
-
   # Raised when the Neocities API returns a non-success response.
   #
   # Wraps error messages from the remote API so callers can inspect

--- a/lib/neocities_red/services/common/exclusions.rb
+++ b/lib/neocities_red/services/common/exclusions.rb
@@ -5,9 +5,32 @@ require "pathname"
 module NeocitiesRed
   module Services
     module Common
+      # Builds normalized exclusion lists from user-provided paths.
+      #
+      # Given a list of file or directory paths, expands them into all
+      # contained files and normalizes them relative to a base path.
+      # This is used by {NeocitiesRed::Services::Site::Pusher} to apply
+      # the +--exclude+ option.
+      #
+      # @example
+      #   excluded = Exclusions.build(["node_modules", "secret.txt"], base_path: ".")
+      #   # => ["node_modules/...", "secret.txt"]
+      #
+      # @see NeocitiesRed::Services::Site::Pusher#push Uses exclusions during push
       module Exclusions
         module_function
 
+        # Builds a normalized exclusion list from the given entries.
+        #
+        # For each entry:
+        # - If it is a file, includes it directly
+        # - If it is a directory, recursively includes all contained files
+        # - Non-existent entries are silently skipped
+        #
+        # @param excluded_entries [Array<String>] file or directory paths to exclude
+        # @param base_path [String, nil] base directory for path normalization;
+        #   when provided, paths are made relative to this base
+        # @return [Array<String>] flattened, deduplicated list of normalized paths
         def build(excluded_entries, base_path: nil)
           base = base_path && Pathname.new(base_path).expand_path
 
@@ -29,6 +52,11 @@ module NeocitiesRed
           end
         end
 
+        # Normalizes a path relative to a base directory.
+        #
+        # @param path [String] absolute or relative path
+        # @param base [String, nil] base directory; when nil, returns the path as-is
+        # @return [String] the path relative to +base+, or the original path
         def normalize(path, base)
           return path unless base
 

--- a/lib/neocities_red/services/common/exclusions.rb
+++ b/lib/neocities_red/services/common/exclusions.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require "pathname"
+
+module NeocitiesRed
+  module Services
+    module Common
+      module Exclusions
+        module_function
+
+        def build(excluded_entries, base_path: nil)
+          base = base_path && Pathname.new(base_path).expand_path
+
+          excluded_entries.flat_map do |entry|
+            target = base ? Pathname.new(entry).expand_path : Pathname.new(entry).cleanpath
+            next [] unless target.exist?
+
+            paths =
+              if ::File.file?(target)
+                [target.to_s]
+              elsif ::File.directory?(target)
+                Dir.glob(::File.join(target, "**", "*"), ::File::FNM_DOTMATCH)
+              else
+                []
+              end
+
+            paths.push(target.to_s) if ::File.directory?(target)
+            paths.map { |path| normalize(path, base) }.uniq
+          end
+        end
+
+        def normalize(path, base)
+          return path unless base
+
+          Pathname.new(path).expand_path.relative_path_from(base).to_s
+        end
+        private_class_method :normalize
+      end
+    end
+  end
+end

--- a/lib/neocities_red/services/common/pizza.rb
+++ b/lib/neocities_red/services/common/pizza.rb
@@ -4,8 +4,18 @@ require "pastel"
 
 module NeocitiesRed
   module Services
+    # Shared service utilities used across file and site operations.
     module Common
+      # Easter egg — returns a random humorous excuse for why pizza
+      # is unavailable.
+      #
+      # Invoked via the +neocities-red pizza+ CLI command.
+      #
+      # @example
+      #   excuse = Pizza.new.make_order
+      #   puts excuse
       class Pizza
+        # @return [Array<String>] pool of humorous pizza excuses
         EXCUSES = [
           "Sorry, we're fresh out of pineapple today.",
           "All the toppings just went rogue and are currently answering to no god.",
@@ -24,12 +34,12 @@ module NeocitiesRed
           <<~TEXT
             WAR AND PEACE, BY LEO TOLSTOY, BOOK ONE: 1805, CHAPTER I
 
-            “Well, Prince, so Genoa and Lucca are now just family estates of the Buonapartes.
-            But I warn you, if you don’t tell me that this means war, if you still try to defend
+            "Well, Prince, so Genoa and Lucca are now just family estates of the Buonapartes.
+            But I warn you, if you don't tell me that this means war, if you still try to defend
             the infamies and horrors perpetrated by that Antichrist—I really believe he is
             Antichrist—I will have nothing more to do with you and you are no longer my friend,
-            no longer my ‘faithful slave,’ as you call yourself! But how do you do? I see I have
-            frightened you—sit down and tell me all the news.”
+            no longer my 'faithful slave,' as you call yourself! But how do you do? I see I have
+            frightened you—sit down and tell me all the news."
 
             It was in July, 1805, and the speaker was the well-known Anna Pávlovna Schérer,
             maid of honor and favorite of the Empress Márya Fëdorovna. With these words she
@@ -42,11 +52,11 @@ module NeocitiesRed
             All her invitations without exception, written in French, and delivered by a
             scarlet-liveried footman that morning, ran as follows:
 
-            “If you have nothing better to do, Count (or Prince), and if the prospect of
+            "If you have nothing better to do, Count (or Prince), and if the prospect of
             spending an evening with a poor invalid is not too terrible, I shall be very
-            charmed to see you tonight between 7 and 10—Annette Schérer.”
+            charmed to see you tonight between 7 and 10—Annette Schérer."
 
-            “Heavens! what a virulent attack!” replied the prince, not in the least disconcerted
+            "Heavens! what a virulent attack!" replied the prince, not in the least disconcerted
             by this reception.
 
             He had just entered, wearing an embroidered court uniform, knee breeches, and
@@ -59,32 +69,32 @@ module NeocitiesRed
             He went up to Anna Pávlovna, kissed her hand, presenting to her his bald, scented,
             and shining head, and complacently seated himself on the sofa.
 
-            “First of all, dear friend, tell me how you are. Set your friend’s mind at rest,”
+            "First of all, dear friend, tell me how you are. Set your friend's mind at rest,"
             said he without altering his tone, beneath the politeness and affected sympathy of
             which indifference and even irony could be discerned.
 
-            “Can one be well while suffering morally? Can one be calm in times like these if
-            one has any feeling?” said Anna Pávlovna. “You are staying the whole evening, I hope?”
+            "Can one be well while suffering morally? Can one be calm in times like these if
+            one has any feeling?" said Anna Pávlovna. "You are staying the whole evening, I hope?"
 
-            “And the fete at the English ambassador’s? Today is Wednesday. I must put in an
-            appearance there,” said the prince. “My daughter is coming for me to take me there.”
+            "And the fete at the English ambassador's? Today is Wednesday. I must put in an
+            appearance there," said the prince. "My daughter is coming for me to take me there."
 
-            “I thought today’s fete had been canceled. I confess all these festivities and
-            fireworks are becoming wearisome.”
+            "I thought today's fete had been canceled. I confess all these festivities and
+            fireworks are becoming wearisome."
 
-            “If they had known that you wished it, the entertainment would have been put off,”
+            "If they had known that you wished it, the entertainment would have been put off,"
             said the prince, who, like a wound-up clock, by force of habit said things he did
             not even wish to be believed.
 
-            “Don’t tease! Well, and what has been decided about Novosíltsev’s dispatch?
-            You know everything.”
+            "Don't tease! Well, and what has been decided about Novosíltsev's dispatch?
+            You know everything."
 
-            “What can one say about it?” replied the prince in a cold, listless tone.
-            “What has been decided? They have decided that Buonaparte has burnt his boats,
-            and I believe that we are ready to burn ours.”
+            "What can one say about it?" replied the prince in a cold, listless tone.
+            "What has been decided? They have decided that Buonaparte has burnt his boats,
+            and I believe that we are ready to burn ours."
 
             Prince Vasíli always spoke languidly, like an actor repeating a stale part.
-            Anna Pávlovna Schérer on the contrary, despite her forty years, overflowed with
+            Anna Pávlovna Schérer on the contrary, despite of her forty years, overflowed with
             animation and impulsiveness.
 
             To be an enthusiast had become her social vocation and, sometimes even when she
@@ -98,6 +108,9 @@ module NeocitiesRed
           TEXT
         ].freeze
 
+        # Returns a random pizza excuse.
+        #
+        # @return [String] a humorous excuse rendered in bright red via Pastel
         def make_order
           Pastel.new(enabled: true).bright_red(EXCUSES.sample)
         end

--- a/lib/neocities_red/services/common/worker_pool.rb
+++ b/lib/neocities_red/services/common/worker_pool.rb
@@ -3,12 +3,34 @@
 module NeocitiesRed
   module Services
     module Common
+      # A simple thread pool for parallel task execution.
+      #
+      # Processes a list of items concurrently using a fixed number of
+      # worker threads. Each item is passed to the block provided at
+      # construction time.
+      #
+      # @example
+      #   pool = WorkerPool.new(5) { |item| puts item }
+      #   pool.process([1, 2, 3, 4, 5])
+      #
+      # @see NeocitiesRed::Services::File::FolderUploader Uses for parallel uploads
+      # @see NeocitiesRed::Services::Site::Pusher Uses for parallel uploads
       class WorkerPool
+        # @param size [Integer] number of concurrent worker threads
+        # @yield [item] block to execute for each item
+        # @yieldparam item [Object] an item from the processing queue
         def initialize(size, &block)
           @size = size
           @block = block
         end
 
+        # Processes all items in the pool using worker threads.
+        #
+        # Items are placed in a thread-safe queue and consumed by workers.
+        # The method blocks until all items have been processed.
+        #
+        # @param items [Array<Object>] items to process
+        # @return [void]
         def process(items)
           queue = Queue.new
           items.each { |item| queue << item }

--- a/lib/neocities_red/services/common/worker_pool.rb
+++ b/lib/neocities_red/services/common/worker_pool.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module NeocitiesRed
+  module Services
+    module Common
+      class WorkerPool
+        def initialize(size, &block)
+          @size = size
+          @block = block
+        end
+
+        def process(items)
+          queue = Queue.new
+          items.each { |item| queue << item }
+
+          workers = Array.new(@size) do
+            Thread.new do
+              loop do
+                item = queue.pop(true)
+                @block.call(item)
+              rescue ThreadError
+                break
+              end
+            end
+          end
+
+          workers.each(&:join)
+        end
+      end
+    end
+  end
+end

--- a/lib/neocities_red/services/file/folder_uploader.rb
+++ b/lib/neocities_red/services/file/folder_uploader.rb
@@ -5,11 +5,29 @@ require "pathname"
 module NeocitiesRed
   module Services
     module File
-      # warning - the big quantity of working threads could be considered like-a DDOS.
-      # Your ip-address could get banned for a few days.
+      # Maximum number of concurrent upload threads.
+      #
+      # Warning: a high thread count may be flagged as DDOS-like traffic
+      # by Neocities, potentially resulting in a temporary IP ban.
       MAX_THREADS = 5
 
+      # Uploads all files in a local directory to the remote site in parallel.
+      #
+      # Uses a {Services::Common::WorkerPool} to upload files concurrently
+      # up to {MAX_THREADS} threads. Each file is uploaded via {Uploader}.
+      #
+      # @example
+      #   folder = NeocitiesRed::Services::File::FolderUploader.new(client, "./dist", "assets", display: display)
+      #   files = folder.files
+      #   folder.upload(files)
+      #
+      # @see NeocitiesRed::Services::File::Uploader Individual file upload
+      # @see NeocitiesRed::Services::Common::WorkerPool Thread pool
       class FolderUploader
+        # @param client [NeocitiesRed::Client] authenticated API client
+        # @param filepath [String] local directory path to upload
+        # @param remote_path [String] remote destination directory
+        # @param display [NeocitiesRed::CliDisplay] output helper
         def initialize(client, filepath, remote_path, display: NeocitiesRed::CliDisplay.new)
           @client = client
           @filepath = filepath
@@ -17,6 +35,11 @@ module NeocitiesRed
           @display = display
         end
 
+        # Recursively lists all files in the local directory.
+        #
+        # @return [Array<String>] relative file paths within the directory
+        # @raise [NeocitiesRed::FileNotFoundError] if the directory does not exist
+        # @return [nil] if the path is a file (not a directory)
         def files
           path = Pathname.new(::File.expand_path(@filepath))
 
@@ -33,6 +56,11 @@ module NeocitiesRed
           end
         end
 
+        # Uploads all files in the list concurrently.
+        #
+        # @param files_list [Array<String>] relative file paths to upload
+        # @param threads [Integer] maximum concurrent upload threads (default: {MAX_THREADS})
+        # @return [void]
         def upload(files_list, threads = MAX_THREADS)
           base = ::File.expand_path(@filepath)
 

--- a/lib/neocities_red/services/file/folder_uploader.rb
+++ b/lib/neocities_red/services/file/folder_uploader.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "pathname"
-require "pastel"
 
 module NeocitiesRed
   module Services
@@ -11,20 +10,20 @@ module NeocitiesRed
       MAX_THREADS = 5
 
       class FolderUploader
-        def initialize(client, filepath, remote_path)
+        def initialize(client, filepath, remote_path, display: NeocitiesRed::CliDisplay.new)
           @client = client
           @filepath = filepath
           @remote_path = remote_path
-          @pastel = Pastel.new(eachline: "\n")
+          @display = display
         end
 
         def files
           path = Pathname.new(::File.expand_path(@filepath))
 
-          raise FileIsNotExists, "#{path} does not exist locally." unless path.exist?
+          raise NeocitiesRed::FileNotFoundError, "#{path} does not exist locally." unless path.exist?
 
           if path.file?
-            puts @pastel.bold("#{path} is not a directory, skipping")
+            @display.display_skip_file(path)
             return
           end
 
@@ -37,27 +36,14 @@ module NeocitiesRed
         def upload(files_list, threads = MAX_THREADS)
           base = ::File.expand_path(@filepath)
 
-          queue = Queue.new
-          files_list.each { |file| queue << file }
+          worker_pool = Services::Common::WorkerPool.new(threads) do |file|
+            local_path  = ::File.join(base, file)
+            remote_path = ::File.join(@remote_path, file)
 
-          workers = Array.new(threads) do
-            Thread.new do
-              loop do
-                begin
-                  file = queue.pop(true)
-                rescue ThreadError
-                  break
-                end
-
-                local_path  = ::File.join(base, file)
-                remote_path = ::File.join(@remote_path, file)
-
-                Uploader.new(@client, local_path, remote_path).upload
-              end
-            end
+            Uploader.new(@client, local_path, remote_path, display: @display).upload
           end
 
-          workers.each(&:join)
+          worker_pool.process(files_list)
         end
       end
     end

--- a/lib/neocities_red/services/file/list.rb
+++ b/lib/neocities_red/services/file/list.rb
@@ -6,8 +6,28 @@ require "tty/table"
 
 module NeocitiesRed
   module Services
+    # File-level operations: upload, delete, and list.
     module File
+      # Lists files on the remote Neocities site.
+      #
+      # Supports both a simple list mode and a detailed table mode
+      # with file size, SHA1 hash, and last-updated timestamp.
+      #
+      # @example Simple listing
+      #   list = NeocitiesRed::Services::File::List.new(client, nil, false, display: display)
+      #   files = list.show
+      #
+      # @example Detailed table
+      #   list = NeocitiesRed::Services::File::List.new(client, nil, true, display: display)
+      #   list.show  # renders TTY::Table
+      #
+      # @see NeocitiesRed::Client#list Underlying API call
       class List
+        # @param client [NeocitiesRed::Client] authenticated API client
+        # @param path [String, nil] remote directory path to list (nil for root)
+        # @param detail [Boolean] when true, renders a detailed table with
+        #   size, hash, and timestamp columns
+        # @param display [NeocitiesRed::CliDisplay] output helper
         def initialize(client, path, detail, display: NeocitiesRed::CliDisplay.new)
           @client = client
           @path = path
@@ -16,10 +36,22 @@ module NeocitiesRed
           @pastel = Pastel.new(eachline: "\n")
         end
 
+        # Returns the raw list of remote files.
+        #
+        # @return [Array<Hash>] array of file hashes with +:path+, +:is_directory+,
+        #   +:size+, +:sha1_hash+, and +:updated_at+ keys
+        # @raise [NeocitiesRed::APIError] if the API returns an error
         def list
           files_from_response
         end
 
+        # Returns the file list, optionally rendered as a detailed table.
+        #
+        # In detail mode, displays a colored table with Path, Size, SHA1 Hash,
+        # and Updated columns. Directories are shown in blue, files in green.
+        #
+        # @return [Array<Hash>] the file list hashes
+        # @raise [NeocitiesRed::APIError] if the API returns an error
         def show
           files = files_from_response
 
@@ -46,6 +78,10 @@ module NeocitiesRed
 
         private
 
+        # Fetches and validates the file list from the API.
+        #
+        # @return [Array<Hash>] file hashes from the API response
+        # @raise [NeocitiesRed::APIError] if the response indicates an error
         def files_from_response
           resp = @client.list(@path)
 

--- a/lib/neocities_red/services/file/list.rb
+++ b/lib/neocities_red/services/file/list.rb
@@ -8,56 +8,50 @@ module NeocitiesRed
   module Services
     module File
       class List
-        def initialize(client, path, detail)
+        def initialize(client, path, detail, display: NeocitiesRed::CliDisplay.new)
           @client = client
           @path = path
           @detail = detail || false
+          @display = display
           @pastel = Pastel.new(eachline: "\n")
         end
 
         def list
-          resp = @client.list(@path)
-
-          display_error_and_exit(resp) if resp[:result] == "error"
-
-          resp[:files]
+          files_from_response
         end
 
         def show
-          resp = @client.list(@path)
+          files = files_from_response
 
-          display_error_and_exit(resp) if resp[:result] == "error"
+          return files unless @detail
 
-          if @detail
-            out = [
-              [@pastel.bold("Path"), @pastel.bold("Size"), @pastel.bold("sha1_Hash"),
-               @pastel.bold("Updated")]
-            ]
+          out = [
+            [@pastel.bold("Path"), @pastel.bold("Size"), @pastel.bold("sha1_Hash"),
+             @pastel.bold("Updated")]
+          ]
 
-            resp[:files].each do |file|
-              out.push([
-                         @pastel.send(file[:is_directory] ? :blue : :green).bold(file[:path]),
-                         file[:size] || "",
-                         file[:sha1_hash],
-                         Time.parse(file[:updated_at]).localtime
-                       ])
-            end
-
-            puts TTY::Table.new(out)
+          files.each do |file|
+            out.push([
+                       @pastel.send(file[:is_directory] ? :blue : :green).bold(file[:path]),
+                       file[:size] || "",
+                       file[:sha1_hash],
+                       Time.parse(file[:updated_at]).localtime
+                     ])
           end
 
-          resp[:files].map do |file|
-            @pastel.send(file[:is_directory] ? :blue : :green).bold(file[:path])
-          end
+          @display.display_list_table(TTY::Table.new(out))
 
-          resp[:files]
+          files
         end
 
         private
 
-        def display_error_and_exit(resp)
-          puts(resp[:message] || resp[:error_type] || resp.inspect)
-          exit
+        def files_from_response
+          resp = @client.list(@path)
+
+          raise NeocitiesRed::APIError, resp[:message] || resp[:error_type] || resp.inspect if resp[:result] == "error"
+
+          resp[:files]
         end
       end
     end

--- a/lib/neocities_red/services/file/remover.rb
+++ b/lib/neocities_red/services/file/remover.rb
@@ -3,15 +3,34 @@
 module NeocitiesRed
   module Services
     module File
+      # Deletes a single file from the remote Neocities site.
+      #
+      # Displays progress and result feedback via {CliDisplay}.
+      #
+      # @example
+      #   remover = NeocitiesRed::Services::File::Remover.new(client, "old-file.html", display: display)
+      #   remover.remove
+      #
+      # @see NeocitiesRed::Client#delete Underlying delete API call
       class Remover
-        attr_accessor :client, :filepath
+        # @return [NeocitiesRed::Client] the authenticated API client
+        attr_accessor :client
 
+        # @return [String] the remote file path to delete
+        attr_accessor :filepath
+
+        # @param client [NeocitiesRed::Client] authenticated API client
+        # @param filepath [String] remote file path to delete
+        # @param display [NeocitiesRed::CliDisplay] output helper
         def initialize(client, filepath, display: NeocitiesRed::CliDisplay.new)
           @client = client
           @filepath = filepath
           @display = display
         end
 
+        # Deletes the file from the remote site.
+        #
+        # @return [Hash] API response with +:result+ key ("success" or "error")
         def remove
           @display.display_delete_progress(filepath)
 

--- a/lib/neocities_red/services/file/remover.rb
+++ b/lib/neocities_red/services/file/remover.rb
@@ -1,30 +1,26 @@
 # frozen_string_literal: true
 
-require "pastel"
-
 module NeocitiesRed
   module Services
     module File
       class Remover
         attr_accessor :client, :filepath
 
-        def initialize(client, filepath)
+        def initialize(client, filepath, display: NeocitiesRed::CliDisplay.new)
           @client = client
           @filepath = filepath
-          @pastel = Pastel.new(eachline: "\n")
+          @display = display
         end
 
         def remove
-          puts @pastel.bold("Deleting #{filepath} ...")
+          @display.display_delete_progress(filepath)
 
           response = @client.delete(filepath)
 
-          puts @pastel.bold(response[:message]) if response[:result] == "error"
-
-          if response[:result] == "error" && response[:error_type] == "file_exists"
-            print @pastel.yellow.bold("EXISTS")
-          elsif response[:result] == "success"
-            print @pastel.green.bold("SUCCESS")
+          if response[:result] == "success"
+            @display.display_delete_success
+          else
+            @display.display_delete_error(response)
           end
 
           response

--- a/lib/neocities_red/services/file/remover.rb
+++ b/lib/neocities_red/services/file/remover.rb
@@ -14,7 +14,7 @@ module NeocitiesRed
       # @see NeocitiesRed::Client#delete Underlying delete API call
       class Remover
         # @return [NeocitiesRed::Client] the authenticated API client
-        attr_accessor :client
+        attr_reader :client
 
         # @return [String] the remote file path to delete
         attr_accessor :filepath

--- a/lib/neocities_red/services/file/uploader.rb
+++ b/lib/neocities_red/services/file/uploader.rb
@@ -5,7 +5,22 @@ require "pathname"
 module NeocitiesRed
   module Services
     module File
+      # Uploads a single file to the Neocities site.
+      #
+      # Handles display feedback for the upload lifecycle: progress,
+      # success, already-exists, and directory-skip scenarios.
+      #
+      # @example
+      #   uploader = NeocitiesRed::Services::File::Uploader.new(client, "index.html", display: display)
+      #   uploader.upload
+      #
+      # @see NeocitiesRed::Client#upload Underlying upload method
       class Uploader
+        # @param client [NeocitiesRed::Client] authenticated API client
+        # @param filepath [String] local file path to upload
+        # @param remote_path [String, nil] remote destination path;
+        #   defaults to the file's basename
+        # @param display [NeocitiesRed::CliDisplay] output helper
         def initialize(client, filepath, remote_path = nil, display: NeocitiesRed::CliDisplay.new)
           @client = client
           @filepath = filepath
@@ -13,6 +28,13 @@ module NeocitiesRed
           @display = display
         end
 
+        # Uploads the file to the remote site.
+        #
+        # Skips directories with a display message. Computes the SHA1 hash
+        # and skips the upload if the remote file is identical.
+        #
+        # @return [Hash] API response with +:result+ key
+        # @raise [NeocitiesRed::FileNotFoundError] if the local file does not exist
         def upload
           path = Pathname.new(@filepath)
 

--- a/lib/neocities_red/services/file/uploader.rb
+++ b/lib/neocities_red/services/file/uploader.rb
@@ -1,40 +1,38 @@
 # frozen_string_literal: true
 
 require "pathname"
-require "pastel"
 
 module NeocitiesRed
   module Services
     module File
-      class FileIsNotExists < StandardError; end
-
       class Uploader
-        def initialize(client, filepath, remote_path = nil)
+        def initialize(client, filepath, remote_path = nil, display: NeocitiesRed::CliDisplay.new)
           @client = client
           @filepath = filepath
           @remote_path = remote_path
-          @pastel = Pastel.new(eachline: "\n")
+          @display = display
         end
 
         def upload
           path = Pathname.new(@filepath)
 
-          raise FileIsNotExists, "#{path} does not exist locally." unless path.exist?
+          raise NeocitiesRed::FileNotFoundError, "#{path} does not exist locally." unless path.exist?
 
           if path.directory?
-            puts @pastel.bold("#{path} is a directory, skipping")
+            @display.display_skip_directory(path)
             return
           end
 
-          puts @pastel.bold("Uploading #{path} to #{@remote_path} ...")
+          @display.display_upload_progress(path, @remote_path)
 
           response = @client.upload(path, @remote_path)
-          puts response if response[:result] == "error"
 
-          if response[:result] == "error" && response[:error_type] == "file_exists"
-            puts @pastel.yellow.bold("EXISTS")
-          elsif response[:result] == "success"
-            puts @pastel.green.bold("SUCCESS")
+          if response[:result] == "success"
+            @display.display_upload_success
+          elsif response[:result] == "error" && response[:error_type] == "file_exists"
+            @display.display_upload_exists
+          else
+            @display.display_response(response)
           end
 
           response

--- a/lib/neocities_red/services/site/differencer.rb
+++ b/lib/neocities_red/services/site/differencer.rb
@@ -28,27 +28,30 @@ module NeocitiesRed
           Dir.chdir(root_path) do
             paths = Dir.glob(::File.join("**", "*"), ::File::FNM_DOTMATCH)
 
-            local_paths = paths.reject { |path| path.start_with?(".") }
-            local_files = local_paths.select { |path| ::File.file?(path) }.map do |path|
-              {
-                path: path,
-                sha1_hash: Digest::SHA1.file(path).hexdigest
-              }
-            end
-            server_paths = server_files.map { |n| n[:path] }
-
-            server_file_map = server_files.to_h do |file|
+            server_file_entries = server_files.reject { |file| file[:is_directory] }
+            server_paths = server_file_entries.map { |file| file[:path] }
+            server_file_map = server_file_entries.to_h do |file|
               [file[:path], file[:sha1_hash]]
             end
+
+            local_paths = paths
 
             if @ignore_dotfiles
               server_paths = server_paths.reject { |path| path.start_with?(".") }
               local_paths = local_paths.reject { |path| path.start_with?(".") }
             end
 
+            local_files = local_paths.select { |path| ::File.file?(path) }.map do |path|
+              {
+                path: path,
+                sha1_hash: Digest::SHA1.file(path).hexdigest
+              }
+            end
+
             if @exclude.any?
-              server_paths -= @exclude
-              local_paths -= @exclude
+              normalized_exclude = @exclude.map { |path| Pathname.new(path).cleanpath.to_s }
+              server_paths -= normalized_exclude
+              local_paths -= normalized_exclude
             end
 
             removed_paths = server_paths - local_paths

--- a/lib/neocities_red/services/site/differencer.rb
+++ b/lib/neocities_red/services/site/differencer.rb
@@ -6,7 +6,29 @@ require "tty/table"
 module NeocitiesRed
   module Services
     module Site
+      # Compares local files against the remote Neocities site.
+      #
+      # Identifies three categories of differences:
+      # - **Added** — files present locally but not on the server
+      # - **Modified** — files present in both but with different SHA1 hashes
+      # - **Removed** — files present on the server but not locally
+      #
+      # Results are color-coded: green for added, yellow for modified,
+      # red for removed.
+      #
+      # @example
+      #   differencer = NeocitiesRed::Services::Site::Differencer.new(
+      #     client, path: ".", detail: false, ignore_dotfiles: false, exclude: []
+      #   )
+      #   added, modified, removed = differencer.show
+      #
+      # @see NeocitiesRed::Services::File::List Fetches the remote file list
       class Differencer
+        # @param client [NeocitiesRed::Client] authenticated API client
+        # @param path [String] local directory path to compare (default: ".")
+        # @param detail [Boolean] whether to show detailed output (default: false)
+        # @param ignore_dotfiles [Boolean] when true, ignores files starting with "."
+        # @param exclude [Array<String>] local paths to exclude from comparison
         def initialize(client, path: ".", detail: false, ignore_dotfiles: false, exclude: [])
           @client = client
           @path = path
@@ -16,6 +38,11 @@ module NeocitiesRed
           @pastel = Pastel.new(eachline: "\n")
         end
 
+        # Computes the diff between local and remote files.
+        #
+        # @return [Array(Array<String>, Array<String>, Array<String>)]
+        #   a tuple of +[added, modified, removed]+, where each element
+        #   is an array of color-coded file path strings
         def show
           server_files = Services::File::List.new(@client, nil, @detail).show
 

--- a/lib/neocities_red/services/site/exporter.rb
+++ b/lib/neocities_red/services/site/exporter.rb
@@ -30,16 +30,16 @@ module NeocitiesRed
       # @see NeocitiesRed::Client#download Downloads individual files
       class Exporter
         # @return [NeocitiesRed::Client] the authenticated API client
-        attr_accessor :client
+        attr_reader :client
 
         # @return [String] the site name being exported
-        attr_accessor :sitename
+        attr_reader :sitename
 
         # @return [Hash] the current config data (modified in-place with last pull info)
-        attr_accessor :data
+        attr_reader :data
 
         # @return [String] path to the config file for persisting pull metadata
-        attr_accessor :app_config_path
+        attr_reader :app_config_path
 
         # @param client [NeocitiesRed::Client] authenticated API client
         # @param sitename [String] the Neocities site name

--- a/lib/neocities_red/services/site/exporter.rb
+++ b/lib/neocities_red/services/site/exporter.rb
@@ -2,6 +2,9 @@
 
 require "whirly"
 require "pastel"
+require "uri"
+require "time"
+require "fileutils"
 
 module NeocitiesRed
   module Services
@@ -9,11 +12,12 @@ module NeocitiesRed
       class Exporter
         attr_accessor :client, :sitename, :data, :app_config_path
 
-        def initialize(client, sitename, data, app_config_path)
+        def initialize(client, sitename, data, app_config_path, display:)
           @client = client
           @sitename = sitename
           @data = data
           @app_config_path = app_config_path
+          @display = display
           @pastel = Pastel.new(eachline: "\n")
         end
 
@@ -23,7 +27,7 @@ module NeocitiesRed
                          status: "Retrieving files for #{@pastel.bold @sitename}"
           end
 
-          @client.pull(@sitename, last_pull_time, last_pull_loc, quiet: quiet)
+          fetch_files(last_pull_time, last_pull_loc, quiet)
 
           # write last pull data to file (not necessarily the best way to do this, but better than cloning every time)
           data["LAST_PULL"] = {
@@ -31,11 +35,73 @@ module NeocitiesRed
             loc: Dir.pwd
           }
 
-          File.write(app_config_path, data.to_json)
-        rescue StandardError => e
-          e
+          ::File.write(app_config_path, data.to_json)
         ensure
           Whirly.stop if quiet
+        end
+
+        private
+
+        def fetch_files(last_pull_time, last_pull_loc, quiet)
+          site_info = @client.info(@sitename)
+
+          raise NeocitiesRed::APIError, site_info[:message] if site_info[:result] == "error"
+
+          info_data = site_info[:info]
+
+          domain =
+            if info_data[:domain].to_s.empty?
+              "https://#{@sitename}.neocities.org/"
+            else
+              "https://#{info_data[:domain]}/"
+            end
+
+          # start stats
+          success_loaded = 0
+          start_time = Time.now
+          curr_dir = Dir.pwd
+
+          # get list of files
+          resp = @client.list
+
+          raise NeocitiesRed::APIError, resp[:message] if resp[:result] == "error"
+
+          # fetch each file
+          uri_parser = URI::Parser.new
+          resp[:files].each do |file|
+            if file[:is_directory]
+              FileUtils.mkdir_p file[:path].to_s
+            else
+              @display.display_pull_progress(file[:path]) unless quiet
+
+              if last_pull_time &&
+                 last_pull_loc &&
+                 Time.parse(file[:updated_at]) <= Time.parse(last_pull_time) &&
+                 last_pull_loc == curr_dir &&
+                 ::File.exist?(file[:path]) # case when user deletes file
+
+                # case when file hasn't been updated since last
+                @display.display_pull_no_updates unless quiet
+
+                next
+              end
+
+              pathtotry = uri_parser.escape(domain + file[:path])
+              fileconts = @client.download(pathtotry)
+
+              if fileconts.status == 200
+                @display.display_pull_success unless quiet
+                success_loaded += 1
+
+                ::File.write(file[:path].to_s, fileconts.body)
+              elsif !quiet
+                @display.display_pull_failure
+              end
+            end
+          end
+
+          # display stats
+          @display.display_pull_stats(success_loaded, Time.now - start_time)
         end
       end
     end

--- a/lib/neocities_red/services/site/exporter.rb
+++ b/lib/neocities_red/services/site/exporter.rb
@@ -9,9 +9,43 @@ require "fileutils"
 module NeocitiesRed
   module Services
     module Site
+      # Downloads all files from the remote Neocities site to the local filesystem.
+      #
+      # Supports incremental pulls — files that haven't been updated since the
+      # last pull (and exist locally) are skipped. Progress is displayed per-file,
+      # or via a Whirly spinner in quiet mode. Pull metadata (timestamp and
+      # working directory) is persisted in the config file for future incremental
+      # pulls.
+      #
+      # @example Full pull
+      #   exporter = NeocitiesRed::Services::Site::Exporter.new(
+      #     client, "my-site", config_data, config_path, display: display
+      #   )
+      #   exporter.export
+      #
+      # @example Quiet pull with incremental support
+      #   exporter.export(quiet: true, last_pull_time: "2024-01-01", last_pull_loc: "/path/to/site")
+      #
+      # @see NeocitiesRed::Client#list Fetches remote file list
+      # @see NeocitiesRed::Client#download Downloads individual files
       class Exporter
-        attr_accessor :client, :sitename, :data, :app_config_path
+        # @return [NeocitiesRed::Client] the authenticated API client
+        attr_accessor :client
 
+        # @return [String] the site name being exported
+        attr_accessor :sitename
+
+        # @return [Hash] the current config data (modified in-place with last pull info)
+        attr_accessor :data
+
+        # @return [String] path to the config file for persisting pull metadata
+        attr_accessor :app_config_path
+
+        # @param client [NeocitiesRed::Client] authenticated API client
+        # @param sitename [String] the Neocities site name
+        # @param data [Hash] current application config data
+        # @param app_config_path [String] path to the config file
+        # @param display [NeocitiesRed::CliDisplay] output helper
         def initialize(client, sitename, data, app_config_path, display:)
           @client = client
           @sitename = sitename
@@ -21,6 +55,15 @@ module NeocitiesRed
           @pastel = Pastel.new(eachline: "\n")
         end
 
+        # Downloads all site files to the current working directory.
+        #
+        # After the download, persists the current timestamp and working
+        # directory to the config file for future incremental pulls.
+        #
+        # @param quiet [Boolean] when true, shows a spinner instead of per-file output
+        # @param last_pull_time [String, nil] ISO timestamp of the last pull
+        # @param last_pull_loc [String, nil] working directory of the last pull
+        # @return [void]
         def export(quiet: false, last_pull_time: nil, last_pull_loc: nil)
           if quiet
             Whirly.start spinner: ["😺", "😸", "😹", "😻", "😼", "😽", "🙀", "😿", "😾"],
@@ -29,7 +72,6 @@ module NeocitiesRed
 
           fetch_files(last_pull_time, last_pull_loc, quiet)
 
-          # write last pull data to file (not necessarily the best way to do this, but better than cloning every time)
           data["LAST_PULL"] = {
             time: Time.now,
             loc: Dir.pwd
@@ -42,6 +84,16 @@ module NeocitiesRed
 
         private
 
+        # Fetches each file from the remote site and writes it locally.
+        #
+        # Skips files that haven't changed since the last pull when
+        # incremental data is available.
+        #
+        # @param last_pull_time [String, nil] ISO timestamp of the last pull
+        # @param last_pull_loc [String, nil] working directory of the last pull
+        # @param quiet [Boolean] suppresses per-file output when true
+        # @return [void]
+        # @raise [NeocitiesRed::APIError] if the site info or file list API fails
         def fetch_files(last_pull_time, last_pull_loc, quiet)
           site_info = @client.info(@sitename)
 
@@ -56,17 +108,14 @@ module NeocitiesRed
               "https://#{info_data[:domain]}/"
             end
 
-          # start stats
           success_loaded = 0
           start_time = Time.now
           curr_dir = Dir.pwd
 
-          # get list of files
           resp = @client.list
 
           raise NeocitiesRed::APIError, resp[:message] if resp[:result] == "error"
 
-          # fetch each file
           uri_parser = URI::Parser.new
           resp[:files].each do |file|
             if file[:is_directory]
@@ -78,9 +127,8 @@ module NeocitiesRed
                  last_pull_loc &&
                  Time.parse(file[:updated_at]) <= Time.parse(last_pull_time) &&
                  last_pull_loc == curr_dir &&
-                 ::File.exist?(file[:path]) # case when user deletes file
+                 ::File.exist?(file[:path])
 
-                # case when file hasn't been updated since last
                 @display.display_pull_no_updates unless quiet
 
                 next
@@ -100,7 +148,6 @@ module NeocitiesRed
             end
           end
 
-          # display stats
           @display.display_pull_stats(success_loaded, Time.now - start_time)
         end
       end

--- a/lib/neocities_red/services/site/informer.rb
+++ b/lib/neocities_red/services/site/informer.rb
@@ -5,8 +5,6 @@ require "pastel"
 
 module NeocitiesRed
   module Services
-    class ClientError < StandardError; end
-
     module Site
       class Informer
         attr_accessor :client
@@ -21,7 +19,7 @@ module NeocitiesRed
         def stats
           response = @client.info(@subargs[0] || @sitename)
 
-          raise NeocitiesRed::Services::ClientError, response[:message] if response[:result] == "error"
+          raise NeocitiesRed::APIError, response[:message] if response[:result] == "error"
 
           response
         end

--- a/lib/neocities_red/services/site/informer.rb
+++ b/lib/neocities_red/services/site/informer.rb
@@ -6,9 +6,26 @@ require "pastel"
 module NeocitiesRed
   module Services
     module Site
+      # Retrieves and formats site information for the Neocities site.
+      #
+      # Queries the Neocities API for site metadata (domain, bandwidth,
+      # created_at, last_updated, etc.) and formats it as rows suitable
+      # for display in a TTY::Table.
+      #
+      # @example
+      #   informer = NeocitiesRed::Services::Site::Informer.new(client, ["my-site"], "my-site")
+      #   rows = informer.pretty_print
+      #   puts TTY::Table.new(rows)
+      #
+      # @see NeocitiesRed::Client#info Underlying API call
       class Informer
+        # @return [NeocitiesRed::Client] the authenticated API client
         attr_accessor :client
 
+        # @param client [NeocitiesRed::Client] authenticated API client
+        # @param subargs [Array<String>] CLI subarguments; the first element
+        #   may be a sitename to query
+        # @param sitename [String, nil] default sitename (used when subargs is empty)
         def initialize(client, subargs = [], sitename = nil)
           @client = client
           @subargs = subargs
@@ -16,6 +33,10 @@ module NeocitiesRed
           @pastel = Pastel.new(eachline: "\n")
         end
 
+        # Fetches site information from the Neocities API.
+        #
+        # @return [Hash] parsed API response containing +:info+ with site metadata
+        # @raise [NeocitiesRed::APIError] if the API returns an error
         def stats
           response = @client.info(@subargs[0] || @sitename)
 
@@ -24,6 +45,12 @@ module NeocitiesRed
           response
         end
 
+        # Formats the site stats as bold-labeled rows.
+        #
+        # Timestamp fields (+created_at+, +last_updated+) are converted
+        # to local time for readability.
+        #
+        # @return [Array<Array(String, Object)>] array of +[label, value]+ pairs
         def pretty_print
           out = []
 

--- a/lib/neocities_red/services/site/informer.rb
+++ b/lib/neocities_red/services/site/informer.rb
@@ -20,7 +20,7 @@ module NeocitiesRed
       # @see NeocitiesRed::Client#info Underlying API call
       class Informer
         # @return [NeocitiesRed::Client] the authenticated API client
-        attr_accessor :client
+        attr_reader :client
 
         # @param client [NeocitiesRed::Client] authenticated API client
         # @param subargs [Array<String>] CLI subarguments; the first element

--- a/lib/neocities_red/services/site/informer.rb
+++ b/lib/neocities_red/services/site/informer.rb
@@ -21,7 +21,7 @@ module NeocitiesRed
         def stats
           response = @client.info(@subargs[0] || @sitename)
 
-          raise NeocitiesRed::Services::ClientError, response if response[:result] == "error"
+          raise NeocitiesRed::Services::ClientError, response[:message] if response[:result] == "error"
 
           response
         end

--- a/lib/neocities_red/services/site/pusher.rb
+++ b/lib/neocities_red/services/site/pusher.rb
@@ -5,11 +5,45 @@ require "digest"
 
 module NeocitiesRed
   module Services
+    # Site-level operations: push, diff, info, and export.
     module Site
+      # Recursively uploads a local directory to the Neocities site.
+      #
+      # Orchestrates the full push workflow:
+      # 1. Validates the root path
+      # 2. Optionally prunes remote files not present locally
+      # 3. Collects all files via glob
+      # 4. Applies .gitignore rules, dotfile filtering, exclusions, and
+      #    optimized (hash-based) filtering
+      # 5. Uploads remaining files in parallel via a worker pool
+      #
+      # @example Basic push
+      #   pusher = NeocitiesRed::Services::Site::Pusher.new(
+      #     client, display,
+      #     root: ".", no_gitignore: false, ignore_dotfiles: false,
+      #     exclude: [], dry_run: false, prune: false, optimized: false
+      #   )
+      #   pusher.push
+      #
+      # @see NeocitiesRed::Services::File::Uploader Individual file upload
+      # @see NeocitiesRed::Services::Common::Exclusions Exclusion builder
+      # @see NeocitiesRed::Services::Common::WorkerPool Thread pool
       class Pusher
-        # warning - the big quantity of working threads could be considered like-a DDOS.
-        # Your ip-address could get banned on neocities for a few days.
+        # @return [Integer] maximum concurrent upload threads.
+        #
+        # Warning: a high thread count may be flagged as DDOS-like traffic
+        # by Neocities, potentially resulting in a temporary IP ban.
         MAX_THREADS = 5
+
+        # @param client [NeocitiesRed::Client] authenticated API client
+        # @param display [NeocitiesRed::CliDisplay] output helper
+        # @param root [String] local directory path to push
+        # @param no_gitignore [Boolean] when true, ignores .gitignore rules
+        # @param ignore_dotfiles [Boolean] when true, skips files starting with "."
+        # @param exclude [Array<String>] additional paths to exclude from upload
+        # @param dry_run [Boolean] when true, simulates the push without uploading
+        # @param prune [Boolean] when true, deletes remote files not present locally
+        # @param optimized [Boolean] when true, skips files whose SHA1 matches the server
         def initialize(client, display, root:, no_gitignore:, ignore_dotfiles:, exclude:, dry_run:, prune:, optimized:)
           @client = client
           @display = display
@@ -22,6 +56,10 @@ module NeocitiesRed
           @optimized = optimized
         end
 
+        # Executes the full push workflow.
+        #
+        # @return [void]
+        # @raise [ArgumentError] if the root path does not exist or is not a directory
         def push
           root_path = Pathname(@root)
           validate_root_path!(root_path)
@@ -45,11 +83,22 @@ module NeocitiesRed
 
         private
 
+        # Validates that the root path exists and is a directory.
+        #
+        # @param root_path [Pathname] the local root directory
+        # @raise [ArgumentError] if validation fails
         def validate_root_path!(root_path)
           raise ArgumentError, "path #{root_path} does not exist" unless root_path.exist?
           raise ArgumentError, "provided path is not a directory" unless root_path.directory?
         end
 
+        # Filters file paths based on .gitignore rules.
+        #
+        # Reads the local .gitignore and removes matching paths using
+        # +File.fnmatch+ for glob pattern support.
+        #
+        # @param paths [Array<String>] all file paths in the root
+        # @return [Array<String>> filtered paths not matched by .gitignore
         def apply_gitignore(paths)
           return paths unless ::File.exist?(".gitignore")
 
@@ -65,6 +114,14 @@ module NeocitiesRed
           filtered
         end
 
+        # Computes which files can be skipped because their SHA1 hash
+        # matches the server version.
+        #
+        # Fetches the remote file list, computes local SHA1 hashes, and
+        # returns paths that don't need re-uploading.
+        #
+        # @param paths [Array<String>] all local file paths
+        # @return [Array<String>] file paths to exclude (already up to date)
         def optimized_exclusions(paths)
           hex = paths.select { |path| ::File.file?(path) }
                      .map { |file| { filepath: file, sha1_hash: Digest::SHA1.file(file).hexdigest } }
@@ -80,6 +137,10 @@ module NeocitiesRed
              .map { |entry| entry[:filepath] }
         end
 
+        # Uploads all filtered paths in parallel using a worker pool.
+        #
+        # @param paths [Array<Pathname>] local files to upload
+        # @return [void]
         def upload_files(paths)
           worker_pool = Services::Common::WorkerPool.new(MAX_THREADS) do |path|
             next if path.directory?
@@ -91,6 +152,12 @@ module NeocitiesRed
           @display.display_upload_complete
         end
 
+        # Deletes remote files that no longer exist in the local directory.
+        #
+        # Skips directories that have already been pruned. Respects the
+        # +@dry_run+ flag.
+        #
+        # @return [void]
         def prune_remote_files
           pruned_dirs = []
           resp = @client.list

--- a/lib/neocities_red/services/site/pusher.rb
+++ b/lib/neocities_red/services/site/pusher.rb
@@ -10,7 +10,6 @@ module NeocitiesRed
         # warning - the big quantity of working threads could be considered like-a DDOS.
         # Your ip-address could get banned on neocities for a few days.
         MAX_THREADS = 5
-
         def initialize(client, display, root:, no_gitignore:, ignore_dotfiles:, exclude:, dry_run:, prune:, optimized:)
           @client = client
           @display = display
@@ -30,7 +29,7 @@ module NeocitiesRed
           @display.display_dry_run_notice if @dry_run
           prune_remote_files if @prune
 
-          excluded_files = build_push_exclusions(@exclude)
+          excluded_files = Services::Common::Exclusions.build(@exclude)
 
           Dir.chdir(root_path) do
             paths = Dir.glob(::File.join("**", "*"), ::File::FNM_DOTMATCH)
@@ -49,22 +48,6 @@ module NeocitiesRed
         def validate_root_path!(root_path)
           raise ArgumentError, "path #{root_path} does not exist" unless root_path.exist?
           raise ArgumentError, "provided path is not a directory" unless root_path.directory?
-        end
-
-        def build_push_exclusions(excluded_entries)
-          excluded_files = []
-
-          excluded_entries.each do |entry|
-            filepath = Pathname.new(entry).cleanpath.to_s
-
-            if ::File.file?(filepath)
-              excluded_files << filepath
-            elsif ::File.directory?(filepath)
-              excluded_files.concat(Dir.glob(::File.join(filepath, "**", "*"), ::File::FNM_DOTMATCH).push(filepath))
-            end
-          end
-
-          excluded_files
         end
 
         def apply_gitignore(paths)
@@ -98,27 +81,13 @@ module NeocitiesRed
         end
 
         def upload_files(paths)
-          task_queue = Queue.new
-          paths.each { |path| task_queue.push(path) }
+          worker_pool = Services::Common::WorkerPool.new(MAX_THREADS) do |path|
+            next if path.directory?
 
-          threads = []
-          MAX_THREADS.times do
-            threads << Thread.new do
-              until task_queue.empty?
-                path = begin
-                  task_queue.pop(true)
-                rescue StandardError
-                  nil
-                end
-
-                next if path.nil? || path.directory?
-
-                Services::File::Uploader.new(@client, path, path).upload
-              end
-            end
+            Services::File::Uploader.new(@client, path, path, display: @display).upload
           end
 
-          threads.each(&:join)
+          worker_pool.process(paths)
           @display.display_upload_complete
         end
 

--- a/lib/neocities_red/version.rb
+++ b/lib/neocities_red/version.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
 module NeocitiesRed
+  # The current version of the NeocitiesRed gem.
   VERSION = "1.2.0"
 end

--- a/lib/neocities_red/version.rb
+++ b/lib/neocities_red/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module NeocitiesRed
-  VERSION = "1.1.1"
+  VERSION = "1.1.2"
 end

--- a/lib/neocities_red/version.rb
+++ b/lib/neocities_red/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module NeocitiesRed
-  VERSION = "1.1.2"
+  VERSION = "1.2.0"
 end

--- a/neocities-red.gemspec
+++ b/neocities-red.gemspec
@@ -44,12 +44,16 @@ Gem::Specification.new do |spec|
   spec.add_dependency "faraday-multipart"
   spec.add_dependency "faraday-retry"
   spec.add_dependency "fiddle"
-  spec.add_dependency "pastel", "~> 0.8", "= 0.8.0"
-  spec.add_dependency "rake", "~> 13", ">= 13.3.0"
+  spec.add_dependency "pastel", "= 0.8.0"
+  spec.add_dependency "rake", "~> 13"
   spec.add_dependency "thor", "~> 1.5.0", ">= 1.5.0"
-  spec.add_dependency "tty-prompt", "~> 0.23", "= 0.23.1"
-  spec.add_dependency "tty-table", "~> 0.12", "= 0.12.0"
+  spec.add_dependency "tty-prompt", "= 0.23.1"
+  spec.add_dependency "tty-table", "= 0.12.0"
   spec.add_dependency "whirly", "~> 0.3", ">= 0.3.0"
 
   spec.metadata["rubygems_mfa_required"] = "true"
+  spec.metadata["homepage_uri"] = spec.homepage
+  spec.metadata["source_code_uri"] = "https://github.com/o-200/neocities-red"
+  spec.metadata["changelog_uri"] = "https://github.com/o-200/neocities-red/blob/main/CHANGELOG.md"
+  spec.metadata["documentation_uri"] = "https://github.com/o-200/neocities-red#readme"
 end

--- a/neocities-red.gemspec
+++ b/neocities-red.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   spec.files         = Dir.chdir(File.expand_path(__dir__)) do
     files = begin
       if system("git", "rev-parse", "--is-inside-work-tree", out: File::NULL, err: File::NULL)
-        `git ls-files -z`.split("\x0")
+        `git ls-files -z`.split("\x0").reject { |f| f == ".yardopts" }
       else
         []
       end
@@ -26,7 +26,8 @@ Gem::Specification.new do |spec|
     if files.empty?
       files = Dir.glob("**/*", File::FNM_DOTMATCH).select do |path|
         File.file?(path) &&
-          !path.start_with?("test/", "spec/", "features/", ".git/", ".github/", ".rubocop_cache/")
+          !path.start_with?("test/", "spec/", "features/", ".git/", ".github/", ".rubocop_cache/") &&
+            path != ".yardopts"
       end
     end
 

--- a/neocities-red.gemspec
+++ b/neocities-red.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
       files = Dir.glob("**/*", File::FNM_DOTMATCH).select do |path|
         File.file?(path) &&
           !path.start_with?("test/", "spec/", "features/", ".git/", ".github/", ".rubocop_cache/") &&
-            path != ".yardopts"
+          path != ".yardopts"
       end
     end
 

--- a/spec/neocities_red/cli_display_spec.rb
+++ b/spec/neocities_red/cli_display_spec.rb
@@ -81,12 +81,6 @@ RSpec.describe NeocitiesRed::CliDisplay do
   end
 
   describe "status helpers" do
-    it "prints unknown option" do
-      display.display_unknown_option("--wat")
-
-      expect(text_output).to include('Unknown option: "--wat"')
-    end
-
     it "prints delete progress and success on the same line" do
       display.display_delete_progress("foo.txt")
       display.display_delete_success

--- a/spec/neocities_red/cli_spec.rb
+++ b/spec/neocities_red/cli_spec.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 require "spec_helper"
+require "tmpdir"
+require "fileutils"
+require "json"
+require "stringio"
 
 RSpec.describe NeocitiesRed::CLI do
   describe ".app_config_path" do
@@ -63,6 +67,87 @@ RSpec.describe NeocitiesRed::CLI do
 
       path = described_class.app_config_path(app_name)
       expect(path).to eq(File.join("/home/alice", ".#{app_name}"))
+    end
+  end
+
+  describe "#persist_config" do
+    let(:tmp_dir) { Dir.mktmpdir }
+    let(:config_path) { File.join(tmp_dir, "config.json") }
+    let(:cli) { described_class.new }
+
+    before do
+      allow(cli).to receive(:app_config_path).and_return(config_path)
+    end
+
+    after do
+      FileUtils.rm_rf(tmp_dir)
+    end
+
+    it "writes the config with 0600 permissions" do
+      cli.send(:persist_config, API_KEY: "secret", SITENAME: "test-site")
+
+      expect(File.read(config_path)).to eq('{"API_KEY":"secret","SITENAME":"test-site"}')
+      expect(File.stat(config_path).mode & 0o777).to eq(0o600)
+    end
+  end
+
+  describe "purge" do
+    around do |example|
+      # rubocop:disable RSpec/ExpectOutput
+      original_stdout = $stdout
+      $stdout = StringIO.new
+      example.run
+    ensure
+      $stdout = original_stdout
+    end
+    # rubocop:enable RSpec/ExpectOutput
+
+    let(:tmp_dir) { Dir.mktmpdir }
+    let(:config_path) { File.join(tmp_dir, "config.json") }
+
+    before do
+      allow(described_class).to receive(:app_config_path).and_return(tmp_dir)
+      File.write(config_path, JSON.generate(API_KEY: "test-key", SITENAME: "test-site"))
+
+      stub_request(:get, %r{https://neocities\.org/api/list})
+        .to_return(body: {
+          result: "success",
+          files: [
+            { path: "index.html", is_directory: false },
+            { path: "gone_dir", is_directory: true }
+          ]
+        }.to_json)
+    end
+
+    after do
+      WebMock.reset!
+      FileUtils.rm_rf(tmp_dir)
+    end
+
+    it "deletes listed files when confirmed" do
+      stub_request(:post, %r{https://neocities\.org/api/delete})
+        .to_return(body: { result: "success" }.to_json)
+
+      described_class.start(%w[purge -y])
+
+      expect(a_request(:post, %r{https://neocities\.org/api/delete}))
+        .to have_been_made.twice
+    end
+
+    it "does not delete anything with --dry-run" do
+      described_class.start(%w[purge -y --dry-run])
+
+      expect(a_request(:post, %r{https://neocities\.org/api/delete}))
+        .not_to have_been_made
+    end
+
+    it "shows help when -y is missing" do
+      expect { described_class.start(%w[purge]) }.to raise_error(SystemExit)
+
+      expect(a_request(:post, %r{https://neocities\.org/api/delete}))
+        .not_to have_been_made
+      expect(a_request(:get, %r{https://neocities\.org/api/list}))
+        .not_to have_been_made
     end
   end
 end

--- a/spec/neocities_red/cli_spec.rb
+++ b/spec/neocities_red/cli_spec.rb
@@ -87,6 +87,7 @@ RSpec.describe NeocitiesRed::CLI do
       cli.send(:persist_config, API_KEY: "secret", SITENAME: "test-site")
 
       expect(File.read(config_path)).to eq('{"API_KEY":"secret","SITENAME":"test-site"}')
+      skip "chmod is a no-op on Windows" if Gem.win_platform?
       expect(File.stat(config_path).mode & 0o777).to eq(0o600)
     end
   end

--- a/spec/neocities_red/client_spec.rb
+++ b/spec/neocities_red/client_spec.rb
@@ -191,7 +191,7 @@ RSpec.describe NeocitiesRed::Client do
       end
 
       context "when file already exists on server with same hash" do
-        let(:mock_hash_response) { { result: "success", files: { :"test_upload.txt" => true } } }
+        let(:mock_hash_response) { { result: "success", files: { "test_upload.txt": true } } }
 
         before do
           allow(client).to receive(:upload_hash).and_return(mock_hash_response)

--- a/spec/neocities_red/client_spec.rb
+++ b/spec/neocities_red/client_spec.rb
@@ -191,7 +191,7 @@ RSpec.describe NeocitiesRed::Client do
       end
 
       context "when file already exists on server with same hash" do
-        let(:mock_hash_response) { { result: "success", files: { "test_upload.txt" => true } } }
+        let(:mock_hash_response) { { result: "success", files: { :"test_upload.txt" => true } } }
 
         before do
           allow(client).to receive(:upload_hash).and_return(mock_hash_response)

--- a/spec/neocities_red/client_spec.rb
+++ b/spec/neocities_red/client_spec.rb
@@ -247,60 +247,17 @@ RSpec.describe NeocitiesRed::Client do
     end
   end
 
-  describe "#pull" do
+  describe "#download" do
     let(:client) { described_class.new(api_key: api_key) }
-    let(:temp_dir) { Dir.mktmpdir }
-    let(:mock_list_response) { { result: "success", files: [] } }
-    let(:mock_info_response) { { result: "success", info: { domain: nil } } }
-
-    around do |example|
-      original_dir = Dir.pwd
-      Dir.chdir(temp_dir)
-      example.run
-    ensure
-      Dir.chdir(original_dir)
-      FileUtils.rm_rf(temp_dir)
-    end
+    let(:mock_conn_response) { instance_double(Faraday::Response, status: 200, body: "raw content") }
 
     before do
-      allow(client).to receive_messages(list: mock_list_response, info: mock_info_response)
-      allow(client.instance_variable_get(:@conn)).to receive(:get).and_return(
-        instance_double(Faraday::Response, status: 200, body: "")
-      )
+      allow(client.instance_variable_get(:@conn)).to receive(:get).and_return(mock_conn_response)
     end
 
-    it "pulls files from the site" do
-      expect { client.pull(sitename, nil, nil, quiet: true) }.not_to raise_error
-    end
-
-    it "supports last_pull_time and last_pull_loc parameters" do
-      last_pull_time = Time.now - 86_400
-      last_pull_loc = Dir.pwd
-      expect { client.pull(sitename, last_pull_time, last_pull_loc, quiet: true) }.not_to raise_error
-    end
-
-    context "when site has custom domain" do
-      let(:mock_info_response) { { result: "success", info: { domain: "example.com" } } }
-
-      it "uses the custom domain for fetching files" do
-        expect { client.pull(sitename, nil, nil, quiet: true) }.not_to raise_error
-      end
-    end
-
-    context "when API returns error for info" do
-      let(:mock_info_response) { { result: "error", message: "Site not found" } }
-
-      it "raises an error" do
-        expect { client.pull(sitename, nil, nil, quiet: true) }.to raise_error(ArgumentError, /Site not found/)
-      end
-    end
-
-    context "when API returns error for list" do
-      let(:mock_list_response) { { result: "error", message: "List failed" } }
-
-      it "raises an error" do
-        expect { client.pull(sitename, nil, nil, quiet: true) }.to raise_error(ArgumentError, /List failed/)
-      end
+    it "returns the raw Faraday response for a url" do
+      response = client.download("https://example.com/index.html")
+      expect(response).to eq(mock_conn_response)
     end
   end
 end

--- a/spec/neocities_red/services/common/exclusions_spec.rb
+++ b/spec/neocities_red/services/common/exclusions_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "fileutils"
+require "tmpdir"
+
+RSpec.describe NeocitiesRed::Services::Common::Exclusions do
+  let(:tmp_root) { Dir.mktmpdir("exclusions_spec") }
+
+  before do
+    FileUtils.mkdir_p(File.join(tmp_root, "node_modules"))
+    File.write(File.join(tmp_root, "node_modules", "dep.js"), "x")
+    File.write(File.join(tmp_root, "secret.txt"), "x")
+    File.write(File.join(tmp_root, "keep.txt"), "x")
+  end
+
+  after do
+    FileUtils.rm_rf(tmp_root)
+  end
+
+  describe ".build" do
+    it "returns an empty list for entries that do not exist" do
+      expect(described_class.build([File.join(tmp_root, "nope")])).to eq([])
+    end
+
+    it "returns the path for an existing file" do
+      expect(described_class.build([File.join(tmp_root, "secret.txt")]))
+        .to eq([File.join(tmp_root, "secret.txt")])
+    end
+
+    it "returns the directory and all of its children for an existing directory" do
+      entries = described_class.build([File.join(tmp_root, "node_modules")])
+
+      expect(entries).to include(File.join(tmp_root, "node_modules"))
+      expect(entries).to include(File.join(tmp_root, "node_modules", "dep.js"))
+    end
+
+    it "normalizes paths relative to base_path when given" do
+      entries = described_class.build(
+        [File.join(tmp_root, "secret.txt"), File.join(tmp_root, "node_modules")],
+        base_path: tmp_root
+      )
+
+      expect(entries).to contain_exactly("secret.txt", "node_modules", "node_modules/dep.js")
+    end
+  end
+end

--- a/spec/neocities_red/services/common/worker_pool_spec.rb
+++ b/spec/neocities_red/services/common/worker_pool_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe NeocitiesRed::Services::Common::WorkerPool do
+  let(:result) { [] }
+  let(:mutex) { Mutex.new }
+
+  def pool_of(size)
+    described_class.new(size) do |item|
+      mutex.synchronize { result << item }
+    end
+  end
+
+  describe "#process" do
+    it "calls the block for each item" do
+      pool_of(3).process([1, 2, 3, 4, 5])
+
+      expect(result.sort).to eq([1, 2, 3, 4, 5])
+    end
+
+    it "processes items across multiple threads" do
+      threads_seen = []
+      pool = described_class.new(4) do |item|
+        sleep 0.002
+        threads_seen << Thread.current.object_id
+        result << item
+      end
+
+      pool.process(Array.new(20, :work))
+
+      expect(threads_seen.uniq.size).to be > 1
+      expect(result.size).to eq(20)
+    end
+
+    it "works with a single worker" do
+      pool_of(1).process(%w[a b c])
+
+      expect(result).to eq(%w[a b c])
+    end
+
+    it "returns immediately for an empty list" do
+      expect { pool_of(2).process([]) }.not_to raise_error
+
+      expect(result).to be_empty
+    end
+  end
+end

--- a/spec/neocities_red/services/file/folder_uploader_spec.rb
+++ b/spec/neocities_red/services/file/folder_uploader_spec.rb
@@ -6,6 +6,7 @@ require "fileutils"
 RSpec.describe NeocitiesRed::Services::File::FolderUploader do
   let(:client) { instance_double(NeocitiesRed::Client) }
   let(:remote_path) { "ext/" }
+  let(:display) { instance_double(NeocitiesRed::CliDisplay, display_skip_file: nil) }
 
   let(:spec_root) { File.expand_path("..", __dir__) } # => ./spec
   let(:tmp_root)  { File.join(spec_root, "tmp", "folder_uploader_spec") }
@@ -26,9 +27,9 @@ RSpec.describe NeocitiesRed::Services::File::FolderUploader do
   end
 
   describe "#files" do
-    it "raises FileIsNotExists when the path does not exist" do
-      uploader = described_class.new(client, File.join(tmp_root, "nope"), remote_path)
-      expect { uploader.files }.to raise_error(NeocitiesRed::Services::File::FileIsNotExists)
+    it "raises FileNotFoundError when the path does not exist" do
+      uploader = described_class.new(client, File.join(tmp_root, "nope"), remote_path, display: display)
+      expect { uploader.files }.to raise_error(NeocitiesRed::FileNotFoundError)
     end
 
     it "returns all files under the directory as relative paths, including dotfiles, excluding directories" do
@@ -40,7 +41,7 @@ RSpec.describe NeocitiesRed::Services::File::FolderUploader do
       FileUtils.mkdir_p(File.join(tmp_root, "ext/empty_dir"))
       FileUtils.mkdir_p(File.join(tmp_root, "ext/.hiddendir"))
 
-      uploader = described_class.new(client, File.join(tmp_root, "ext"), remote_path)
+      uploader = described_class.new(client, File.join(tmp_root, "ext"), remote_path, display: display)
       expect(uploader.files).to contain_exactly("a.txt", "sub/b.txt", ".env", "sub/.keep")
     end
 
@@ -49,16 +50,17 @@ RSpec.describe NeocitiesRed::Services::File::FolderUploader do
       write_file("tmp_ext/sub/nested.rb", content: "puts :ok")
 
       Dir.chdir(tmp_root) do
-        uploader = described_class.new(client, "./tmp_ext/", remote_path)
+        uploader = described_class.new(client, "./tmp_ext/", remote_path, display: display)
         expect(uploader.files).to contain_exactly("root.rb", "sub/nested.rb")
       end
     end
 
     it "returns nil when filepath is a file (not a directory)" do
       file_path = write_file("not_a_dir.txt", content: "hello")
-      uploader = described_class.new(client, file_path, remote_path)
+      uploader = described_class.new(client, file_path, remote_path, display: display)
 
       expect(uploader.files).to be_nil
+      expect(display).to have_received(:display_skip_file)
     end
   end
 end

--- a/spec/neocities_red/services/file/list_spec.rb
+++ b/spec/neocities_red/services/file/list_spec.rb
@@ -7,7 +7,8 @@ RSpec.describe NeocitiesRed::Services::File::List do
   let(:client) { instance_double(NeocitiesRed::Client) }
   let(:path) { nil }
   let(:detail) { false }
-  let(:file_list) { described_class.new(client, path, detail) }
+  let(:display) { instance_double(NeocitiesRed::CliDisplay, display_list_table: nil) }
+  let(:file_list) { described_class.new(client, path, detail, display: display) }
 
   describe "#list" do
     context "when successful" do
@@ -58,11 +59,10 @@ RSpec.describe NeocitiesRed::Services::File::List do
 
       before do
         allow(client).to receive(:list).and_return(error_response)
-        allow($stdout).to receive(:puts)
       end
 
-      it "displays the error and exits" do
-        expect { file_list.list }.to raise_error(SystemExit)
+      it "raises APIError with the message" do
+        expect { file_list.list }.to raise_error(NeocitiesRed::APIError, /Invalid path/)
       end
     end
   end
@@ -81,7 +81,6 @@ RSpec.describe NeocitiesRed::Services::File::List do
 
       before do
         allow(client).to receive(:list).with(path).and_return(files_response)
-        allow($stdout).to receive(:puts)
       end
 
       it "returns an array of files" do
@@ -119,7 +118,6 @@ RSpec.describe NeocitiesRed::Services::File::List do
         allow(pastel).to receive_messages(blue: pastel, green: pastel)
         allow(TTY::Table).to receive(:new).and_return(table)
         allow(table).to receive(:to_s).and_return("table output")
-        allow($stdout).to receive(:puts)
       end
 
       it "returns files with detailed information" do
@@ -142,6 +140,12 @@ RSpec.describe NeocitiesRed::Services::File::List do
 
         expect(pastel).to have_received(:green).at_least(:once)
       end
+
+      it "renders the table through the display" do
+        file_list.show
+
+        expect(display).to have_received(:display_list_table).with(table)
+      end
     end
 
     context "when API returns an error" do
@@ -149,11 +153,10 @@ RSpec.describe NeocitiesRed::Services::File::List do
 
       before do
         allow(client).to receive(:list).and_return(error_response)
-        allow($stdout).to receive(:puts)
       end
 
-      it "displays the error and exits" do
-        expect { file_list.show }.to raise_error(SystemExit)
+      it "raises APIError with the message" do
+        expect { file_list.show }.to raise_error(NeocitiesRed::APIError, /Path not found/)
       end
     end
   end
@@ -166,7 +169,7 @@ RSpec.describe NeocitiesRed::Services::File::List do
     end
 
     it "handles nil detail as false" do
-      file_list_nil_detail = described_class.new(client, path, nil)
+      file_list_nil_detail = described_class.new(client, path, nil, display: display)
       expect(file_list_nil_detail.instance_variable_get(:@detail)).to be(false)
     end
 

--- a/spec/neocities_red/services/file/remover_spec.rb
+++ b/spec/neocities_red/services/file/remover_spec.rb
@@ -1,21 +1,19 @@
 # frozen_string_literal: true
 
 require "spec_helper"
-require "stringio"
 
 RSpec.describe NeocitiesRed::Services::File::Remover do
-  subject(:remover) { described_class.new(client, filepath) }
+  subject(:remover) { described_class.new(client, filepath, display: display) }
 
   let(:client) { instance_double(NeocitiesRed::Client) }
   let(:filepath) { "test_file.txt" }
-  let(:io) { StringIO.new }
-  let(:pastel) { object_double(Pastel.new(eachline: "\n")) }
-
-  before do
-    allow(Pastel).to receive(:new).with(eachline: "\n").and_return(pastel)
-    allow(pastel).to receive(:bold) { |msg| msg }
-    allow(pastel).to receive_messages(green: pastel, yellow: pastel)
-    allow($stdout).to receive_messages(puts: nil, print: nil)
+  let(:display) do
+    instance_double(
+      NeocitiesRed::CliDisplay,
+      display_delete_progress: nil,
+      display_delete_success: nil,
+      display_delete_error: nil
+    )
   end
 
   describe "#initialize" do
@@ -46,14 +44,10 @@ RSpec.describe NeocitiesRed::Services::File::Remover do
         expect(client).to have_received(:delete).with(filepath)
       end
 
-      it "prints deletion progress message" do
+      it "displays delete progress and success" do
         remover.remove
-        expect(pastel).to have_received(:bold).with("Deleting #{filepath} ...")
-      end
-
-      it "prints SUCCESS message" do
-        remover.remove
-        expect(pastel).to have_received(:green)
+        expect(display).to have_received(:display_delete_progress).with(filepath)
+        expect(display).to have_received(:display_delete_success)
       end
 
       it "returns the success response" do
@@ -76,9 +70,9 @@ RSpec.describe NeocitiesRed::Services::File::Remover do
         expect(client).to have_received(:delete).with(filepath)
       end
 
-      it "prints error message" do
+      it "displays delete error" do
         remover.remove
-        expect(pastel).to have_received(:bold).with("File not found")
+        expect(display).to have_received(:display_delete_error).with(error_response)
       end
 
       it "returns the error response" do
@@ -96,9 +90,9 @@ RSpec.describe NeocitiesRed::Services::File::Remover do
         allow(client).to receive(:delete).with(filepath).and_return(exists_response)
       end
 
-      it "prints EXISTS message" do
+      it "displays delete error" do
         remover.remove
-        expect(pastel).to have_received(:yellow)
+        expect(display).to have_received(:display_delete_error).with(exists_response)
       end
 
       it "returns the error response" do

--- a/spec/neocities_red/services/file/uploader_spec.rb
+++ b/spec/neocities_red/services/file/uploader_spec.rb
@@ -1,13 +1,22 @@
 # frozen_string_literal: true
 
-require "fileutils"
 require "spec_helper"
 
 RSpec.describe NeocitiesRed::Services::File::Uploader do
   let(:client) { instance_double(NeocitiesRed::Client) }
   let(:filepath) { "/path/to/file.txt" }
   let(:remote_path) { "file.txt" }
-  let(:uploader) { described_class.new(client, filepath, remote_path) }
+  let(:display) do
+    instance_double(
+      NeocitiesRed::CliDisplay,
+      display_skip_directory: nil,
+      display_upload_progress: nil,
+      display_upload_success: nil,
+      display_upload_exists: nil,
+      display_response: nil
+    )
+  end
+  let(:uploader) { described_class.new(client, filepath, remote_path, display: display) }
 
   describe "#upload" do
     context "when the file does not exist" do
@@ -15,9 +24,9 @@ RSpec.describe NeocitiesRed::Services::File::Uploader do
         allow(Pathname).to receive(:new).with(filepath).and_return(instance_double(Pathname, exist?: false))
       end
 
-      it "raises FileIsNotExists error" do
+      it "raises FileNotFoundError" do
         expect { uploader.upload }.to raise_error(
-          NeocitiesRed::Services::File::FileIsNotExists,
+          NeocitiesRed::FileNotFoundError,
           /does not exist locally/
         )
       end
@@ -29,13 +38,12 @@ RSpec.describe NeocitiesRed::Services::File::Uploader do
       before do
         allow(Pathname).to receive(:new).with(filepath).and_return(path_double)
         allow(client).to receive(:upload)
-        allow($stdout).to receive(:puts)
       end
 
-      it "prints a message and returns without uploading" do
+      it "displays a skip message and returns without uploading" do
         uploader.upload
 
-        expect($stdout).to have_received(:puts).with(match(/#{Regexp.escape(filepath)} is a directory, skipping/))
+        expect(display).to have_received(:display_skip_directory).with(path_double)
         expect(client).not_to have_received(:upload)
       end
     end
@@ -46,7 +54,6 @@ RSpec.describe NeocitiesRed::Services::File::Uploader do
 
       before do
         allow(Pathname).to receive(:new).with(filepath).and_return(path_double)
-        allow($stdout).to receive(:puts)
       end
 
       context "when upload is successful" do
@@ -60,10 +67,11 @@ RSpec.describe NeocitiesRed::Services::File::Uploader do
           expect(client).to have_received(:upload).with(path_double, remote_path)
         end
 
-        it "prints success message" do
+        it "displays progress and success" do
           uploader.upload
 
-          expect($stdout).to have_received(:puts).with(/SUCCESS/)
+          expect(display).to have_received(:display_upload_progress).with(path_double, remote_path)
+          expect(display).to have_received(:display_upload_success)
         end
 
         it "returns the success response" do
@@ -86,10 +94,10 @@ RSpec.describe NeocitiesRed::Services::File::Uploader do
           allow(client).to receive(:upload).with(path_double, remote_path).and_return(exists_response)
         end
 
-        it "prints exists message" do
+        it "displays exists message" do
           uploader.upload
 
-          expect($stdout).to have_received(:puts).with(/EXISTS/)
+          expect(display).to have_received(:display_upload_exists)
         end
 
         it "returns the error response" do
@@ -108,12 +116,10 @@ RSpec.describe NeocitiesRed::Services::File::Uploader do
           allow(client).to receive(:upload).with(path_double, remote_path).and_return(error_response)
         end
 
-        it "prints error message" do
+        it "displays the error response" do
           uploader.upload
 
-          expect($stdout).to have_received(:puts).with(
-            hash_including(result: "error", error_type: "upload_failed", message: "Upload failed")
-          )
+          expect(display).to have_received(:display_response).with(error_response)
         end
 
         it "returns the error response" do
@@ -127,13 +133,12 @@ RSpec.describe NeocitiesRed::Services::File::Uploader do
     context "with custom remote path" do
       let(:custom_remote_path) { "custom/path/file.txt" }
       let(:path_double) { instance_double(Pathname, exist?: true, directory?: false, to_s: filepath) }
-      let(:custom_uploader) { described_class.new(client, filepath, custom_remote_path) }
+      let(:custom_uploader) { described_class.new(client, filepath, custom_remote_path, display: display) }
       let(:success_response) { { result: "success", message: "File uploaded successfully" } }
 
       before do
         allow(Pathname).to receive(:new).with(filepath).and_return(path_double)
         allow(client).to receive(:upload).with(path_double, custom_remote_path).and_return(success_response)
-        allow($stdout).to receive(:puts)
       end
 
       it "uses the custom remote path" do
@@ -151,8 +156,8 @@ RSpec.describe NeocitiesRed::Services::File::Uploader do
       expect(uploader.instance_variable_get(:@remote_path)).to eq(remote_path)
     end
 
-    it "creates a Pastel instance" do
-      expect(uploader.instance_variable_get(:@pastel)).to be_a(Pastel::Delegator)
+    it "stores the display" do
+      expect(uploader.instance_variable_get(:@display)).to eq(display)
     end
   end
 end

--- a/spec/neocities_red/services/site/differencer_spec.rb
+++ b/spec/neocities_red/services/site/differencer_spec.rb
@@ -72,6 +72,7 @@ RSpec.describe NeocitiesRed::Services::Site::Differencer do
         .with(File.join("**", "*"), File::FNM_DOTMATCH)
         .and_return(globbed_paths)
 
+      allow(File).to receive(:file?).and_return(false)
       allow(File).to receive(:file?).with("index.html").and_return(true)
       allow(File).to receive(:file?).with("about.html").and_return(true)
       allow(File).to receive(:file?).with("contact.html").and_return(true)
@@ -88,7 +89,7 @@ RSpec.describe NeocitiesRed::Services::Site::Differencer do
     it "returns added, modified and removed paths" do
       added_paths, modified_paths, removed_paths = service.show
 
-      expect(added_paths).to eq(["GREEN(contact.html)", "GREEN(assets)"])
+      expect(added_paths).to eq(["GREEN(contact.html)", "GREEN(assets)", "GREEN(.git)", "GREEN(.env)"])
       expect(modified_paths).to eq(["YELLOW(about.html)"])
       expect(removed_paths).to eq(["RED(old.html)"])
     end
@@ -110,11 +111,11 @@ RSpec.describe NeocitiesRed::Services::Site::Differencer do
       expect(Digest::SHA1).not_to have_received(:file).with("assets")
     end
 
-    it "always excludes dotfiles and dot-directories from local paths" do
+    it "includes dotfiles and dot-directories by default" do
       added_paths, = service.show
 
-      expect(added_paths).not_to include("GREEN(.git)")
-      expect(added_paths).not_to include("GREEN(.env)")
+      expect(added_paths).to include("GREEN(.git)")
+      expect(added_paths).to include("GREEN(.env)")
     end
 
     context "when exclude is provided" do
@@ -123,7 +124,7 @@ RSpec.describe NeocitiesRed::Services::Site::Differencer do
       it "excludes paths from diff" do
         added_paths, modified_paths, removed_paths = service.show
 
-        expect(added_paths).to eq(["GREEN(assets)"])
+        expect(added_paths).to eq(["GREEN(assets)", "GREEN(.git)", "GREEN(.env)"])
         expect(modified_paths).to eq(["YELLOW(about.html)"])
         expect(removed_paths).to eq([])
       end
@@ -132,12 +133,37 @@ RSpec.describe NeocitiesRed::Services::Site::Differencer do
     context "when ignore_dotfiles is true" do
       let(:ignore_dotfiles) { true }
 
-      it "still returns the same result because dotfiles are already filtered earlier" do
+      it "excludes dotfiles and dot-directories" do
         added_paths, modified_paths, removed_paths = service.show
 
         expect(added_paths).to eq(["GREEN(contact.html)", "GREEN(assets)"])
+        expect(added_paths).not_to include("GREEN(.git)")
+        expect(added_paths).not_to include("GREEN(.env)")
         expect(modified_paths).to eq(["YELLOW(about.html)"])
         expect(removed_paths).to eq(["RED(old.html)"])
+      end
+
+      it "does not hash dotfiles" do
+        service.show
+
+        expect(Digest::SHA1).not_to have_received(:file).with(".env")
+      end
+    end
+
+    context "when server has directories" do
+      let(:server_files) do
+        [
+          { path: "index.html", sha1_hash: "server-index-sha", is_directory: false },
+          { path: "assets", is_directory: true },
+          { path: "old.html", sha1_hash: "server-old-sha", is_directory: false }
+        ]
+      end
+
+      it "does not list server directories as removed" do
+        _, _, removed_paths = service.show
+
+        expect(removed_paths).to eq(["RED(old.html)"])
+        expect(removed_paths).not_to include("RED(assets)")
       end
     end
   end

--- a/spec/neocities_red/services/site/exporter_spec.rb
+++ b/spec/neocities_red/services/site/exporter_spec.rb
@@ -3,6 +3,7 @@
 require "spec_helper"
 require "json"
 require "fileutils"
+require "time"
 
 RSpec.describe NeocitiesRed::Services::Site::Exporter do
   let(:client) { instance_double(NeocitiesRed::Client) }
@@ -11,29 +12,42 @@ RSpec.describe NeocitiesRed::Services::Site::Exporter do
   let(:tmp_root) { File.join(spec_root, "tmp", "site_exporter_spec") }
   let(:config_path) { File.join(tmp_root, "config.json") }
   let(:data) { { "LAST_PULL" => { "time" => nil, "loc" => nil } } }
+  let(:display) do
+    instance_double(
+      NeocitiesRed::CliDisplay,
+      display_pull_progress: nil,
+      display_pull_no_updates: nil,
+      display_pull_success: nil,
+      display_pull_failure: nil,
+      display_pull_stats: nil
+    )
+  end
+  let(:exporter) { described_class.new(client, sitename, data, config_path, display: display) }
+  let(:info_response) { { result: "success", info: { domain: nil } } }
+  let(:list_response) { { result: "success", files: [] } }
 
-  before do
+  around do |example|
     FileUtils.rm_rf(tmp_root)
     FileUtils.mkdir_p(tmp_root)
     File.write(config_path, data.to_json)
-  end
 
-  after do
+    original_dir = Dir.pwd
+    Dir.chdir(tmp_root)
+    example.run
+  ensure
+    Dir.chdir(original_dir)
     FileUtils.rm_rf(tmp_root)
   end
 
+  before do
+    allow(client).to receive_messages(info: info_response, list: list_response)
+  end
+
   describe "#export" do
-    context "when pull is successful" do
-      let(:exporter) { described_class.new(client, sitename, data, config_path) }
-
-      before do
-        allow(client).to receive(:pull).and_return(nil)
-      end
-
-      it "pulls files from the site and updates the config file" do
+    context "when the site has no files" do
+      it "updates the config file with last pull data" do
         expect { exporter.export(quiet: true, last_pull_time: nil, last_pull_loc: nil) }.not_to raise_error
 
-        expect(File.exist?(config_path)).to be(true)
         updated_data = JSON.parse(File.read(config_path))
         expect(updated_data["LAST_PULL"]).to have_key("time")
         expect(updated_data["LAST_PULL"]).to have_key("loc")
@@ -62,51 +76,104 @@ RSpec.describe NeocitiesRed::Services::Site::Exporter do
         expect(Whirly).not_to have_received(:stop)
       end
 
-      context "with last_pull_time and last_pull_loc" do
-        let(:last_pull_time) { "2024-01-01T00:00:00Z" }
-        let(:last_pull_loc) { tmp_root }
+      it "displays pull stats" do
+        exporter.export(quiet: false, last_pull_time: nil, last_pull_loc: nil)
 
-        it "passes last_pull parameters to client.pull" do
-          expect { exporter.export(quiet: true, last_pull_time: last_pull_time, last_pull_loc: last_pull_loc) }.not_to raise_error
-
-          expect(client).to have_received(:pull).with(
-            sitename, last_pull_time, last_pull_loc, quiet: true
-          )
-        end
+        expect(display).to have_received(:display_pull_stats).with(0, anything)
       end
     end
 
-    context "when pull raises an error" do
-      let(:exporter) { described_class.new(client, sitename, data, config_path) }
+    context "when the site has files" do
+      let(:list_response) do
+        {
+          result: "success",
+          files: [
+            { path: "index.html", is_directory: false, updated_at: "2024-01-01T00:00:00Z" },
+            { path: "assets/", is_directory: true, updated_at: "2024-01-01T00:00:00Z" }
+          ]
+        }
+      end
+      let(:file_response) { instance_double(Faraday::Response, status: 200, body: "<h1>Hello</h1>") }
 
-      it "stops Whirly and returns the error" do
-        allow(Whirly).to receive(:start)
-        allow(Whirly).to receive(:stop)
-        allow(client).to receive(:pull).and_raise(StandardError.new("network error"))
+      it "downloads files and writes them locally" do
+        allow(client).to receive(:download).with("https://test-site.neocities.org/index.html").and_return(file_response)
 
-        result = exporter.export(quiet: true, last_pull_time: nil, last_pull_loc: nil)
+        exporter.export(quiet: false, last_pull_time: nil, last_pull_loc: nil)
 
-        expect(result).to be_a(StandardError)
-        expect(result.message).to eq("network error")
-        expect(Whirly).to have_received(:stop)
+        expect(File.read(File.join(tmp_root, "index.html"))).to eq("<h1>Hello</h1>")
+        expect(File.directory?(File.join(tmp_root, "assets"))).to be(true)
+        expect(display).to have_received(:display_pull_success)
       end
 
-      it "does not raise and returns an error object" do
+      it "uses the custom domain when present" do
+        allow(client).to receive(:info).and_return(result: "success", info: { domain: "example.com" })
+        allow(client).to receive(:download).with("https://example.com/index.html").and_return(file_response)
+
+        exporter.export(quiet: false, last_pull_time: nil, last_pull_loc: nil)
+
+        expect(client).to have_received(:download).with("https://example.com/index.html")
+      end
+
+      it "skips download when the file has not changed since last pull" do
+        allow(client).to receive(:download)
+        File.write(File.join(tmp_root, "index.html"), "existing content")
+
+        last_pull_time = Time.now.iso8601
+        exporter.export(quiet: false, last_pull_time: last_pull_time, last_pull_loc: Dir.pwd)
+
+        expect(display).to have_received(:display_pull_no_updates)
+        expect(client).not_to have_received(:download)
+        expect(File.read(File.join(tmp_root, "index.html"))).to eq("existing content")
+      end
+
+      it "reports failure when the download fails" do
+        allow(client).to receive(:download).with("https://test-site.neocities.org/index.html").and_return(
+          instance_double(Faraday::Response, status: 500, body: "")
+        )
+
+        exporter.export(quiet: false, last_pull_time: nil, last_pull_loc: nil)
+
+        expect(display).to have_received(:display_pull_failure)
+        expect(File.exist?(File.join(tmp_root, "index.html"))).to be(false)
+      end
+    end
+
+    context "when the API returns an error for info" do
+      let(:info_response) { { result: "error", message: "Site not found" } }
+
+      it "raises APIError" do
+        expect do
+          exporter.export(quiet: true, last_pull_time: nil, last_pull_loc: nil)
+        end.to raise_error(NeocitiesRed::APIError, /Site not found/)
+      end
+    end
+
+    context "when the API returns an error for list" do
+      let(:list_response) { { result: "error", message: "List failed" } }
+
+      it "raises APIError" do
+        expect do
+          exporter.export(quiet: true, last_pull_time: nil, last_pull_loc: nil)
+        end.to raise_error(NeocitiesRed::APIError, /List failed/)
+      end
+    end
+
+    context "when fetching raises an error" do
+      it "propagates the error and stops Whirly" do
+        allow(client).to receive(:info).and_raise(StandardError.new("network error"))
         allow(Whirly).to receive(:start)
         allow(Whirly).to receive(:stop)
-        allow(client).to receive(:pull).and_raise(StandardError.new("network error"))
 
-        result = nil
-        expect { result = exporter.export(quiet: true, last_pull_time: nil, last_pull_loc: nil) }.not_to raise_error
-        expect(result).to be_a(StandardError)
+        expect do
+          exporter.export(quiet: true, last_pull_time: nil, last_pull_loc: nil)
+        end.to raise_error(StandardError, "network error")
+        expect(Whirly).to have_received(:stop)
       end
     end
   end
 
   describe "#initialize" do
     it "stores client, sitename, data, and app_config_path" do
-      exporter = described_class.new(client, sitename, data, config_path)
-
       expect(exporter.client).to eq(client)
       expect(exporter.sitename).to eq(sitename)
       expect(exporter.data).to eq(data)

--- a/spec/neocities_red/services/site/informer_spec.rb
+++ b/spec/neocities_red/services/site/informer_spec.rb
@@ -54,10 +54,10 @@ RSpec.describe NeocitiesRed::Services::Site::Informer do
         allow(client).to receive(:info).and_return(error_response)
       end
 
-      it "raises ClientError" do
+      it "raises ClientError with the message" do
         expect { profile_info.stats }.to raise_error(
           NeocitiesRed::Services::ClientError,
-          /site_not_found/
+          /could not find site nonexistent/
         )
       end
     end

--- a/spec/neocities_red/services/site/informer_spec.rb
+++ b/spec/neocities_red/services/site/informer_spec.rb
@@ -54,9 +54,9 @@ RSpec.describe NeocitiesRed::Services::Site::Informer do
         allow(client).to receive(:info).and_return(error_response)
       end
 
-      it "raises ClientError with the message" do
+      it "raises APIError with the message" do
         expect { profile_info.stats }.to raise_error(
-          NeocitiesRed::Services::ClientError,
+          NeocitiesRed::APIError,
           /could not find site nonexistent/
         )
       end

--- a/spec/neocities_red/services/site/pusher_spec.rb
+++ b/spec/neocities_red/services/site/pusher_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe NeocitiesRed::Services::Site::Pusher do
   end
 
   before do
-    allow(NeocitiesRed::Services::File::Uploader).to receive(:new) do |_client, filepath, remote_path|
+    allow(NeocitiesRed::Services::File::Uploader).to receive(:new) do |_client, filepath, remote_path, _display|
       upload_calls << [filepath.to_s, remote_path.to_s]
       uploader_instance
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,7 +2,7 @@
 
 require "neocities_red"
 require "fileutils"
-require "webmock"
+require "webmock/rspec"
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure


### PR DESCRIPTION
### 1. Moved `pull` logic out of the client into `Exporter`
`pull` used to be a giant "god method" inside `Client`. Now:
- `Client` is slim — only simple HTTP methods.
- `Exporter` downloads the site, creates folders, skips unchanged files, and writes the "last pulled" timestamp.
- Error swallowing removed — failures now propagate properly instead of silently returning an exception object.

### 2. Unified output through `CliDisplay`
`Uploader`, `FolderUploader`, `Remover`, `List` used to call `puts` directly. Now each receives a `CliDisplay` object and asks it to render messages. Output is uniform, easy to test, and changeable in one place.

### 3. Removed `exit` from services
`List` used to print an error and call `exit` itself. Now services only **raise `APIError`**; the CLI catches it and displays it. Services no longer control the program's lifetime.

### 4. Error hierarchy
Created `errors.rb`: `Error` → `AuthenticationError`, `APIError`, `FileNotFoundError`. Replaced the scattered `FileIsNotExists` and `ClientError`.

### 5. Shared thread pool (`WorkerPool`)
The "N threads + task queue" logic was duplicated in `Pusher` and `FolderUploader`. Extracted into `Services::Common::WorkerPool`.

### 6. Unified exclusion logic
`--exclude` in `diff` and `push` used to compute exclusions differently. Now one shared helper: `Services::Common::Exclusions`.